### PR TITLE
docs: trim V3 API Reference nav

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -378,28 +378,6 @@
             "tab": "API Reference",
             "groups": [
               {
-                "group": "Order",
-                "pages": [
-                  "api-reference/v3/order/create",
-                  "api-reference/v3/order/get-status",
-                  "api-reference/v3/order/get"
-                ]
-              },
-              {
-                "group": "Payment",
-                "pages": [
-                  "api-reference/v3/payment/list",
-                  "api-reference/v3/payment/get"
-                ]
-              },
-              {
-                "group": "Card Tokens",
-                "pages": [
-                  "api-reference/v3/card-tokens/list",
-                  "api-reference/v3/card-tokens/delete"
-                ]
-              },
-              {
                 "group": "Merchant",
                 "pages": [
                   "api-reference/v3/merchant/create",
@@ -422,21 +400,6 @@
                   "api-reference/v3/refunds/create",
                   "api-reference/v3/refunds/list",
                   "api-reference/v3/refunds/get"
-                ]
-              },
-              {
-                "group": "Payment Links",
-                "pages": [
-                  "api-reference/v3/payment-link/create",
-                  "api-reference/v3/payment-link/list",
-                  "api-reference/v3/payment-link/retrieve",
-                  "api-reference/v3/payment-link/deactivate"
-                ]
-              },
-              {
-                "group": "Utilities",
-                "pages": [
-                  "api-reference/v3/bin-lookup/lookup"
                 ]
               },
               {


### PR DESCRIPTION
## Summary
Removes the following groups from the **Version 3 → API Reference** navigation in `docs.json`:
- Order
- Payment
- Card Tokens
- Payment Links
- Utilities

V3 API Reference now shows only: **Merchant**, **Settlement**, **Refund**, and **Webhooks**.

## Notes
- Scoped to Version 3 only — Versions 1 and 2 navigation are unchanged.
- Only the nav links were removed; the underlying `.mdx` files are untouched.