### PR TITLE
docs: drop redundant version labels from guide copy; revert Steps to Integrate

### DIFF
--- a/integration-guide/v3/getting-started/introduction.mdx
+++ b/integration-guide/v3/getting-started/introduction.mdx
@@ -1,22 +1,22 @@
 ---
 title: 'Introduction'
-description: 'EximPe V3 is an API-only cross-border collection rail. Collect an Indian buyer''s rupees into an EximPe-issued virtual account and have the funds settled to you abroad — with LRS compliance handled through the API. EximPe shows the buyer no screen.'
+description: 'EximPe is an API-only cross-border collection rail. Collect an Indian buyer''s rupees into an EximPe-issued virtual account and have the funds settled to you abroad — with LRS compliance handled through the API. EximPe shows the buyer no screen.'
 ---
 
 
 <Button href="/integration-guide/v3/getting-started/steps-to-integrate" variant="primary" size="lg">
-  Get Started with EximPe V3
+  Get Started with EximPe
 </Button>
 
-## What V3 Is
+## Overview
 
-V3 is a **headless, API-only** rail for collecting an Indian buyer's rupees into an EximPe-issued **Virtual Bank Account (VBA)** and settling the funds abroad under the RBI **Payment Aggregator – Cross Border (PA-CB)** framework. There is no hosted checkout, no card/UPI payment page — the buyer transfers money to a virtual account, and you assert the compliance details through the API.
+This is a **headless, API-only** rail for collecting an Indian buyer's rupees into an EximPe-issued **Virtual Bank Account (VBA)** and settling the funds abroad under the RBI **Payment Aggregator – Cross Border (PA-CB)** framework. There is no hosted checkout, no card/UPI payment page — the buyer transfers money to a virtual account, and you assert the compliance details through the API.
 
 <Info>
-  Looking for a hosted checkout, payment links, or S2S card/UPI/net-banking collection? Those are **Version 1 / Version 2** flows. V3 does not expose them.
+  Need a hosted checkout, payment links, or S2S card/UPI/net-banking collection instead? Those are earlier-version flows — switch versions from the selector at the top to see their guides.
 </Info>
 
-## Who Uses V3
+## Who Uses It
 
 <CardGroup cols={2}>
   <Card title="PSP" icon="sitemap">
@@ -72,7 +72,7 @@ V3 is a **headless, API-only** rail for collecting an Indian buyer's rupees into
 
 ## Regulatory Framework
 
-V3 operates under the RBI **PA-CB** guidelines. Key constraints to design for:
+EximPe operates under the RBI **PA-CB** guidelines. Key constraints to design for:
 
 - **Per-transaction limit**: ₹2,50,000 per transaction.
 - **LRS TCS threshold**: TCS is nil up to ₹10,00,000 of a remitter's cumulative LRS in a financial year, and applies only to the amount above it (per person, platform-wide, resets each 1 April).

--- a/integration-guide/v3/getting-started/steps-to-integrate.mdx
+++ b/integration-guide/v3/getting-started/steps-to-integrate.mdx
@@ -1,66 +1,32 @@
 ---
 title: "Steps to Integrate"
-description: "Onboard, issue a virtual account, and collect a compliant cross-border payment with EximPe V3."
+description: "Follow these steps to register and collect payments from customer in India"
 ---
 
-This is the end-to-end path for a V3 integration. The collection model is **virtual-account based**: buyers transfer rupees into an EximPe-issued VBA, and you assert LRS compliance through the API.
+## Register for EximPe Account
 
-## 1. Register for an EximPe Account
+In order to collect Payments from Indian Buyers as a foreign merchant or PA collecting payments on behalf of your merchants, first you need to [Register](/integration-guide/getting-started/register-merchant) on EximPe to get your API Access key and token.
 
-To collect payments from Indian buyers as a foreign merchant, or as a **PSP** collecting on behalf of the merchants you onboard, first [register](/integration-guide/v3/getting-started/register-merchant) on EximPe to get your API access credentials.
+To start the development, you can signup to [Merchant Sandbox](https://merchant-uat.eximpe.com/). Please ensure to select **PSP** or **Merchant** based on your business requirement while creating the account.
 
-To start development, sign up on the [Merchant Sandbox](https://merchant-uat.eximpe.com/). Select **PSP** or **Merchant** based on your business model when creating the account.
+## Get API Credentials
 
-## 2. Get API Credentials
-
-Grab your `client_id` and `client_secret` to make secure API calls. See [Get Credentials for API Access](/integration-guide/v3/getting-started/test-credentials).
-
-Every V3 request is authenticated with these headers:
-
-| Header | Purpose |
-| :--- | :--- |
-| `X-Client-ID` | Your client ID |
-| `X-Client-Secret` | Your client secret |
-| `X-API-Version` | API channel/version (e.g. `3.0.0`) |
-| `X-Merchant-ID` | The settling sub-merchant. Required for PSP callers on merchant-scoped calls (VBA, LRS). |
+Grab your `client_id` and `client_secret` to start making secure API calls.\
+Refer to [Get Credentials for Web Checkout & API Access](./test-credentials) to complete this step.
 
 <Note>
-  After signup, share your `client_id` with the EximPe team so we can configure your account, purpose-code allowlist, and approve your webhook URL and IPs in Sandbox.
+  After signup, please share your `client_id` with the EximPe team to configure your account and approve your webhooks and merchant IP in the Sandbox environment.
 </Note>
 
-## 3. Onboard Sub-merchants (PSP)
+## Configure Webhooks & IP Whitelisting
 
-If you are a PSP, create each sub-merchant with the [Create Merchant](/api-reference/v3/merchant/create) API. A sub-merchant must be **approved** before it can hold a VBA or collect. You are notified when it is live via the [Merchant Approved](/api-reference/v3/webhooks/merchant-approved) webhook. See [Adding Merchants](/integration-guide/v3/getting-started/adding-merchants).
+Webhooks are **real-time server-to-server (S2S) notifications** that EximPe sends to your backend when important events occur.
 
-Direct merchants (no parent PSP) skip this step and act as their own settling entity.
+### Setup Guide
 
-## 4. Configure Webhooks & IP Whitelisting
+1.  **Prepare Your Endpoint**: Ensure your server has a **public HTTPS URL** accessible from the internet.
+2.  **Configure Webhook URL**: Log into your **EximPe Dashboard**, navigate to the **Developer Section**, and enter your webhook URL.
+3.  **Whitelist IPs**: Configure your firewall to only accept webhooks from EximPe's IP ranges (found in the Developer Section).
 
-Webhooks are **real-time server-to-server notifications** for merchant, payment, settlement, and refund events.
+For detailed setup instructions, security verification, and supported events, refer to the [Webhooks Guide](../web-integration/webhooks).
 
-1. **Prepare your endpoint** — a public HTTPS URL that returns `200 OK`.
-2. **Configure the webhook URL** in your EximPe Dashboard → Developer Section.
-3. **Whitelist IPs** — restrict your firewall to EximPe's IP ranges (listed in the Developer Section).
-
-See the [Webhooks Guide](/integration-guide/v3/web-integration/webhooks).
-
-## 5. Collect & Comply
-
-<Steps>
-  <Step title="Issue a Virtual Bank Account">
-    Create a VBA for the settling entity and share its account number + IFSC with the buyer. See [Virtual Bank Accounts](/integration-guide/v3/web-integration/virtual-accounts).
-  </Step>
-  <Step title="Receive the credit">
-    When the buyer transfers rupees in, EximPe creates a payment in **Action Required** and fires a payment webhook.
-  </Step>
-  <Step title="Complete LRS verification">
-    Verify the buyer's PAN, quote the TCS, upload documents, and submit the remitter/purpose/declarations. See [LRS Verification](/integration-guide/v3/web-integration/lrs-verification).
-  </Step>
-  <Step title="Settle & reconcile">
-    Track settlement via the [Settlement APIs](/api-reference/v3/settlement/list) and the [Payment Settled](/api-reference/v3/webhooks/payment-settled) webhook.
-  </Step>
-</Steps>
-
-<Info>
-  New to the flow? Start with the [Collection Overview](/integration-guide/v3/web-integration/collection-overview) for the full picture and the roles involved.
-</Info>

--- a/integration-guide/v3/web-integration/collection-overview.mdx
+++ b/integration-guide/v3/web-integration/collection-overview.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Collection Overview"
-description: "The end-to-end V3 flow: issue a virtual account, receive a rupee credit, assert LRS compliance, and settle abroad."
+description: "The end-to-end flow: issue a virtual account, receive a rupee credit, assert LRS compliance, and settle abroad."
 ---
 
-V3 is an **API-only** cross-border collection rail. Unlike V1/V2 (hosted checkout, cards, UPI), the buyer never sees an EximPe screen — they simply transfer rupees into a **Virtual Bank Account (VBA)**, and you assert the compliance details through the API.
+This is an **API-only** cross-border collection rail. The buyer never sees an EximPe screen — they simply transfer rupees into a **Virtual Bank Account (VBA)**, and you assert the compliance details through the API.
 
 ## Roles
 


### PR DESCRIPTION
Follow-up to #58 — this commit was pushed to the #58 branch after it merged, so it's re-landed here.

## Changes
- **Remove 'V3' / 'Version 3' self-references** from the Introduction and Collection Overview copy. The version is chosen from the docs version selector, so repeating it in the body is redundant ("What V3 Is" → "Overview", "Who Uses V3" → "Who Uses It", etc.).
- **Revert Steps to Integrate** to the original (Register → Get Credentials → Configure Webhooks). The collection-flow detail I'd added there now lives in the new Collection Overview / Virtual Accounts / LRS Verification pages, so the rewrite was unnecessary.

No nav or API changes.