### PR TITLE
docs(v3): enrich LRS guide from the partner enablement guide (+ fix TCS rate)

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -359,6 +359,7 @@
                 "pages": [
                   "integration-guide/v3/web-integration/collection-overview",
                   "integration-guide/v3/web-integration/virtual-accounts",
+                  "integration-guide/v3/web-integration/lrs-compliance",
                   "integration-guide/v3/web-integration/lrs-verification",
                   "integration-guide/v3/web-integration/webhooks"
                 ]

--- a/integration-guide/v3/getting-started/introduction.mdx
+++ b/integration-guide/v3/getting-started/introduction.mdx
@@ -10,7 +10,9 @@ description: 'EximPe is an API-only cross-border collection rail. Collect an Ind
 
 ## Overview
 
-This is a **headless, API-only** rail for collecting an Indian buyer's rupees into an EximPe-issued **Virtual Bank Account (VBA)** and settling the funds abroad under the RBI **Payment Aggregator – Cross Border (PA-CB)** framework. There is no hosted checkout, no card/UPI payment page — the buyer transfers money to a virtual account, and you assert the compliance details through the API.
+This is a **headless, API-only** rail for collecting an Indian buyer's rupees into an EximPe-issued **Virtual Bank Account (VBA)** and settling the funds abroad under the RBI **Payment Aggregator – Cross Border (PA-CB)** framework. A bank partner (an **Authorised Dealer**, or "AD bank") performs the actual outward remittance. There is no hosted checkout, no card/UPI payment page — the buyer transfers money to a virtual account, and you assert the compliance details through the API.
+
+You own the entire customer-facing experience and the customer relationship; EximPe is the embedded India collection and settlement engine underneath. You onboard the universities you serve as sub-merchants — collections, settlements, and balances are tracked **per university**.
 
 <Info>
   Need a hosted checkout, payment links, or S2S card/UPI/net-banking collection instead? Those are earlier-version flows — switch versions from the selector at the top to see their guides.
@@ -78,6 +80,8 @@ EximPe operates under the RBI **PA-CB** guidelines. Key constraints to design fo
 - **LRS TCS threshold**: TCS is nil up to ₹10,00,000 of a remitter's cumulative LRS in a financial year, and applies only to the amount above it (per person, platform-wide, resets each 1 April).
 - **Purpose codes**: every payment carries a FEMA purpose code from the settling entity's allowlist.
 - **Documentation**: a digital invoice and supporting documents are required for each remittance; a full audit trail is maintained.
+
+For the full rules — eligibility, the buyer declarations, TCS mechanics, and the education purpose codes and documents — see [LRS & Compliance](/integration-guide/v3/web-integration/lrs-compliance).
 
 <Info>
   **Ready to start?** Follow [Steps to Integrate](/integration-guide/v3/getting-started/steps-to-integrate) to onboard, issue a VBA, and collect your first payment.

--- a/integration-guide/v3/web-integration/collection-overview.mdx
+++ b/integration-guide/v3/web-integration/collection-overview.mdx
@@ -56,6 +56,16 @@ A collected payment moves through these compliance states:
 | `ON_HOLD` | Needs manual attention — e.g. the sender is not the PAN holder. |
 | `SETTLED` | Funds settled to the beneficiary. |
 
+## Edge paths
+
+- **Shortfall** — the buyer paid less than quoted. The payment waits with the outstanding amount; the buyer tops up into the **same VBA**, and you submit the top-up **linked** to the original (`linked_payment_id`).
+- **Discrepancy in review** — if a detail or document is rejected during review, the payment is sent back with exactly what to fix; you re-submit only the flagged item and it returns to review.
+- **Cancellation / overpayment** — issue a refund (full or partial) back to the remitter's **own account**. A payment can take more than one partial refund over its life.
+
+<Note>
+  **Refund funding.** Balances are held **per university**. A refund is netted against the funds EximPe is next due to settle for that university, out of collections not yet settled onward. If enough of that university's balance is held, the refund processes right away; otherwise it waits until enough is collected. Money already settled abroad cannot be pulled back to fund a refund.
+</Note>
+
 ## What You'll Build Against
 
 <CardGroup cols={2}>

--- a/integration-guide/v3/web-integration/lrs-compliance.mdx
+++ b/integration-guide/v3/web-integration/lrs-compliance.mdx
@@ -1,0 +1,117 @@
+---
+title: "LRS & Compliance"
+description: "How the Liberalised Remittance Scheme works, the compliance rules EximPe enforces, the declarations the buyer affirms, TCS mechanics, and the education purpose codes and documents supported."
+---
+
+Most personal outward remittances from India fall under the **Liberalised Remittance Scheme (LRS)**, an RBI/FEMA framework. EximPe is an RBI-authorised **Payment Aggregator – Cross Border (PA-CB)**; a bank partner (an **Authorised Dealer**, or "AD bank") performs the actual outward remittance. Our APIs encode the LRS rules so you supply the remitter, the amount, and the documents — we enforce eligibility, tax, and the annual cap.
+
+## How we work together
+
+You own the customer relationship and everything the customer sees; EximPe is the embedded India collection and settlement engine underneath.
+
+| You (the partner) | EximPe |
+| :--- | :--- |
+| Own the entire customer-facing experience — EximPe shows the customer no screen. | Issues a virtual account, verifies eligibility, computes TCS, files settlement with the AD bank. |
+| Onboard and identify the remitter; collect their details and documents. | Verifies PAN validity, residency affirmation, documents, and declarations. |
+| Provide the INR amount to collect (you handle FX). | Adds only the tax — no FX risk from the EximPe leg. |
+
+<Note>
+  You onboard the **universities** you serve as sub-merchants — each configured with its own settlement details. Collections, settlements, and balances are tracked **per university**. A partner can onboard one or many.
+</Note>
+
+## LRS essentials
+
+- **Who can use it** — resident individuals only (including minors, through a guardian). Not available to companies, partnership firms, HUFs, trusts, or non-resident individuals.
+- **How much** — up to **USD 250,000 per person per financial year** (1 April – 31 March). A hard annual ceiling across all of the individual's LRS remittances at every bank, not just those through EximPe.
+- **Whose money** — the funds must come from the **remitter's own account**. LRS is reported against the **PAN** of the person whose account is debited.
+- **Purpose codes** — every remittance carries a FEMA/FETERS purpose code that declares what it is for and drives which documents and tax rules apply.
+
+## Compliance requirements
+
+<Steps>
+  <Step title="Resident individual only">
+    The remitter must be a resident individual. Verifying the PAN rejects company / HUF / firm PANs automatically. Residency cannot be established from a PAN alone (non-residents hold individual PANs too), so the buyer additionally **affirms residency** in the declarations.
+  </Step>
+  <Step title="Own-account / name-match">
+    Because LRS runs on the PAN of the debited account, the **sender of the money must match the verified remitter**. A credit from a third party's account cannot be settled on someone else's PAN. Where a parent or sponsor pays for a student, **the parent is the remitter** — their PAN is used, their account sends the money — and the relationship to the student is declared.
+  </Step>
+  <Step title="Declarations">
+    The buyer affirms the declarations below; you pass the result to us.
+  </Step>
+</Steps>
+
+### The declarations
+
+The four regulatory requirements — resident-individual status, the LRS limit, source of funds, and TCS — can be presented to the buyer as **two declarations**. Both must be affirmed for the payment to proceed.
+
+**Declaration 1 — Eligibility, LRS limit & source of funds**
+
+> "I am a resident individual under FEMA, and this remittance is under the Liberalised Remittance Scheme. My total LRS this financial year, including this remittance, is within the permitted limit of USD 250,000, and it is for a permitted purpose (not one prohibited under FEMA/RBI). The funds are from my own legitimate sources and comply with FEMA, RBI, AML and income-tax laws. The information in this declaration is true and complete and I accept sole responsibility for its accuracy."
+
+**Declaration 2 — TCS / ₹10 lakh threshold**
+
+> "I have ☐ already exceeded / ☐ not exceeded ₹10,00,000 in LRS remittances this financial year across all banks and channels. I understand that TCS may be collected as applicable under the Income-tax Act, and that the PAN I have furnished is correct."
+
+These map onto the `declarations` object and the `tcs_threshold_breached` flag on [Submit LRS Verification](/api-reference/v3/lrs/submit-verification):
+
+| Declaration | API field |
+| :--- | :--- |
+| Resident individual | `declarations.resident_in_india` |
+| Under the LRS limit | `declarations.lrs` |
+| Source of funds | `declarations.source_of_funds` |
+| TCS understanding | `declarations.tcs` |
+| ₹10 lakh already exceeded? | `tcs_threshold_breached` (`true` = already exceeded) |
+
+## Tax at source (TCS)
+
+For education funded from the remitter's own funds, **TCS is 2% on the amount above ₹10,00,000** of LRS in a financial year — the first ₹10 lakh each year is TCS-free. Declaration 2's ₹10 lakh answer drives the calculation:
+
+- **Already exceeded ₹10 lakh** (`tcs_threshold_breached: true`) → TCS applies to the **full** amount of this payment.
+- **Not exceeded** → EximPe computes against its record of the remitter's LRS through us. If this payment itself crosses ₹10 lakh, TCS applies only to the portion **above** the threshold.
+
+[Quote LRS Amount](/api-reference/v3/lrs/quote) returns the exact TCS; you collect it with the principal. The AD bank deposits the tax against the remitter's PAN, and the remitter reclaims it as a tax credit (it reflects in their Form 26AS / TCS certificate).
+
+<Note>
+  EximPe tracks LRS usage and **refuses any remittance that would breach the USD 250,000 annual cap** on the data available to us; the AD bank is the wider backstop at settlement.
+</Note>
+
+## Purpose codes and documents
+
+EximPe supports these education LRS purpose codes. Documents are decided **by purpose code**. Both are handled as own-funds education (loan-funded remittances are not in scope at present).
+
+| Purpose code | Use |
+| :--- | :--- |
+| `S0305` | Education abroad — studies / tuition (the student typically travels) |
+| `S1107` | Education-related fee remittance (no travel leg) |
+
+| Document (`type`) | S0305 | S1107 |
+| :--- | :--- | :--- |
+| `offer_letter` — offer / admission letter (LOO / LOA) | Mandatory | Mandatory |
+| `fee_invoice` — university fee invoice / demand letter | Optional¹ | Optional¹ |
+| `passport` — of the student | Mandatory | — |
+| `student_id_or_visa` — student ID or visa | Mandatory (ID or visa) | `student_id` only (no visa²) |
+| `relationship_declaration` — parent/sponsor pays | If remitter is not the student | If remitter is not the student |
+
+¹ If the offer/admission letter already carries the fee and bank details, a separate invoice is not required. ² S1107 is a fee remittance with no travel leg, so there is no student visa — the student ID is the enrolment proof.
+
+<Info>
+  PAN is captured as a **field** and validated electronically — a scanned PAN card is not required.
+</Info>
+
+## Best practices
+
+<Warning>
+  The things partners most often get wrong:
+</Warning>
+
+- **Money must come from the remitter's own account.** Enforce it in your UX; where a parent pays, onboard the parent as the remitter (their PAN, their account).
+- **The student is not the remitter.** Capture the student (name, DOB, passport) separately and set `relation` — `SELF` only when they are the same person.
+- **Verify the PAN before you quote.** An inactive, non-individual, or name/DOB-mismatched PAN is a guaranteed bank rejection — catch it upfront.
+- **Show the TCS in the quote, not just FX** — so the remitter pays the full amount and you avoid a later shortfall.
+- **Document quality avoids holds.** Legible, in-date, correct type; the offer/admission letter is the anchor.
+
+---
+
+<Note>
+  This is a product and compliance overview, not legal or tax advice. Ready to build? See [LRS Verification](/integration-guide/v3/web-integration/lrs-verification) for the step-by-step API flow.
+</Note>

--- a/integration-guide/v3/web-integration/lrs-verification.mdx
+++ b/integration-guide/v3/web-integration/lrs-verification.mdx
@@ -9,6 +9,10 @@ Every credit into a VBA creates a payment in **Action Required**. Under the **Li
   **PSP callers must send `X-Merchant-ID`** on every LRS call, naming the settling sub-merchant — LRS is always scoped to the settling entity, never the PSP.
 </Note>
 
+<Info>
+  New to the LRS rules, declarations, and required documents? Read [LRS & Compliance](/integration-guide/v3/web-integration/lrs-compliance) first — this page is the API walk-through.
+</Info>
+
 ## Step 1 — Verify the buyer's PAN
 
 The remitter is identified by **PAN**, not by the bank sender on the credit. [Verify PAN](/api-reference/v3/lrs/verify-pan) checks the PAN against income-tax records and matches the name and date of birth. A verified PAN is the gateway to everything else.
@@ -25,7 +29,7 @@ A non-matching or rejected PAN returns `verified: false` with a `reason` (e.g. `
 
 ## Step 2 — Quote the TCS
 
-[Quote LRS Amount](/api-reference/v3/lrs/quote) returns the TCS due and the all-in total the buyer pays. TCS is **nil up to ₹10,00,000** of the remitter's cumulative LRS this financial year and applies only to the slice above it (education-loan-funded remittances are exempt). This quotes against the LRS usage EximPe can see and reserves nothing.
+[Quote LRS Amount](/api-reference/v3/lrs/quote) returns the TCS due and the all-in total the buyer pays. For education from the buyer's own funds, TCS is **2% on the amount above ₹10,00,000** of the remitter's cumulative LRS this financial year — the first ₹10 lakh each year is TCS-free. This quotes against the LRS usage EximPe can see and reserves nothing.
 
 ```bash
 curl -X POST 'https://api-pacb-uat.eximpe.com/pg/lrs/quote/' \
@@ -49,7 +53,7 @@ curl -X POST 'https://api-pacb-uat.eximpe.com/pg/lrs/documents/' \
   -F 'file=@offer_letter.pdf'
 ```
 
-Document `type` values depend on the purpose code — e.g. `offer_letter`, `fee_invoice`, `passport`, `relationship_declaration`, `student_id_or_visa`.
+Document `type` values depend on the purpose code — e.g. `offer_letter`, `fee_invoice`, `passport`, `relationship_declaration`, `student_id_or_visa`. See the [document matrix](/integration-guide/v3/web-integration/lrs-compliance#purpose-codes-and-documents) for which documents each purpose code requires.
 
 ## Step 4 — Submit verification details
 

--- a/integration-guide/v3/web-integration/virtual-accounts.mdx
+++ b/integration-guide/v3/web-integration/virtual-accounts.mdx
@@ -25,6 +25,10 @@ curl -X POST 'https://api-pacb-uat.eximpe.com/pg/vba/' \
 
 The response carries the `vba_account_number`, `vba_ifsc`, `vba_bank_code`, `vba_status`, and `vba_provider`. **Share the account number and IFSC with the buyer** — that is where they transfer the rupees.
 
+<Note>
+  For ICICI-provider VBAs, the account number is a 16-character number in a fixed pattern: the `INRACC` prefix + a 3-character partner shortcode + a 7-digit identifier — e.g. `INRACCNEX1234567`. The IFSC is fixed per client code.
+</Note>
+
 ### Optional lock rules
 
 You can restrict what a VBA will accept:

--- a/openapi/v3/openapi.json
+++ b/openapi/v3/openapi.json
@@ -2437,7 +2437,7 @@
     "/pg/lrs/quote/": {
       "post": {
         "summary": "Quote TCS and all-in total for a remittance",
-        "description": "Given a verified PAN and a proposed remittance amount (INR), returns the TCS due and the all-in total the buyer pays. TCS is nil up to Rs.10,00,000 of cumulative LRS this financial year and applies only to the slice above it; education-loan-funded remittances are exempt. This quotes against the LRS usage visible to us and reserves nothing. Requires a verified PAN and a `purpose_code` the sub-merchant is enabled for.\n\n**PSP callers must send `X-Merchant-ID`** naming the settling sub-merchant — LRS is always scoped to the settling entity, never the PSP.",
+        "description": "Given a verified PAN and a proposed remittance amount (INR), returns the TCS due and the all-in total the buyer pays. TCS is nil up to Rs.10,00,000 of cumulative LRS this financial year and applies only to the slice above it (for education from the remitter's own funds the rate is 2%); education-loan-funded remittances are exempt. This quotes against the LRS usage visible to us and reserves nothing. Requires a verified PAN and a `purpose_code` the sub-merchant is enabled for.\n\n**PSP callers must send `X-Merchant-ID`** naming the settling sub-merchant — LRS is always scoped to the settling entity, never the PSP.",
         "tags": [
           "LRS"
         ],
@@ -2535,12 +2535,12 @@
                         "tcs_inr": {
                           "type": "string",
                           "description": "TCS due on this remittance (INR).",
-                          "example": "40000.00"
+                          "example": "4000.00"
                         },
                         "total_payable_inr": {
                           "type": "string",
                           "description": "All-in total the buyer pays (remittance + TCS).",
-                          "example": "1240000.00"
+                          "example": "1204000.00"
                         },
                         "tcs_threshold_breached_before": {
                           "type": "boolean",
@@ -2564,8 +2564,8 @@
                     "committed_inr": "0.00",
                     "remittance_inr": "1200000.00",
                     "taxable_inr": "200000.00",
-                    "tcs_inr": "40000.00",
-                    "total_payable_inr": "1240000.00",
+                    "tcs_inr": "4000.00",
+                    "total_payable_inr": "1204000.00",
                     "tcs_threshold_breached_before": false,
                     "tcs_threshold_breached_after": true
                   }
@@ -2892,7 +2892,7 @@
                   "tcs": {
                     "type": "number",
                     "description": "TCS collected from the buyer, in INR rupees.",
-                    "example": 40000
+                    "example": 4000
                   },
                   "declarations": {
                     "type": "object",
@@ -2996,7 +2996,7 @@
                   "email": "john@example.com",
                   "mobile": "9876543210"
                 },
-                "tcs": 40000,
+                "tcs": 4000,
                 "declarations": {
                   "resident_in_india": true,
                   "lrs": true,


### PR DESCRIPTION
## What

Folds the **LRS Education Partner Guide** into the integration docs, and fixes an incorrect TCS rate in the merged LRS examples.

### New page — LRS & Compliance
A product + compliance primer (grounded in the partner guide and verified against the backend):
- LRS essentials — resident-individual only, **USD 250,000/person/FY cap**, own-account/PAN rule, AD-bank execution.
- The **two buyer declarations** (with the exact affirmation text), mapped to the `declarations` object + `tcs_threshold_breached`.
- **TCS mechanics** — 2% above ₹10L for education own-funds; how Declaration 2 drives it; deposited to PAN, reclaimed via Form 26AS.
- **Purpose codes** `S0305` / `S1107` + the **document matrix** (offer letter, fee invoice, passport, student ID/visa, relationship declaration).
- Best practices.

### Enriched existing pages
- **Introduction** — PA-CB / AD-bank model, division of responsibilities (you own the customer, EximPe is the embedded engine), per-university structure.
- **Collection Overview** — edge paths (shortfall top-up via `linked_payment_id`, review discrepancy, cancellation/refund) and the **per-university refund funding** rule.
- **LRS Verification** — TCS 2% education note + cross-link to the document matrix.
- **Virtual Bank Accounts** — ICICI VBA number format (`INRACC` + shortcode + 7-digit, e.g. `INRACCNEX1234567`).

## Fix: TCS rate (correctness)
The merged LRS quote/verify examples implied **20%** TCS. The backend uses `TCS_RATE = Decimal("0.02")` = **2%** above ₹10L for education own-funds. Corrected the examples: `tcs_inr` `40000.00 → 4000.00`, `total_payable_inr` `1240000.00 → 1204000.00`, `verify.tcs` `40000 → 4000`.

## Verified against backend
- TCS: `eximpe_pacb_backend/utils/tcs.py` — `TCS_RATE=0.02`, `TCS_THRESHOLD_CENTS=10,00,000`.
- VA format: `ICICI_ECOLLECTION_CLIENT_CODE` defaults to `INRACC`; `VAN = CLIENT_CODE + PayerID`.

All nav pages resolve; internal links and anchors checked.