### PR TITLE
docs(v3): align integration-guide tone/structure with Version 2

### DIFF
--- a/integration-guide/v3/web-integration/collection-overview.mdx
+++ b/integration-guide/v3/web-integration/collection-overview.mdx
@@ -3,7 +3,21 @@ title: "Collection Overview"
 description: "The end-to-end flow: issue a virtual account, receive a rupee credit, assert LRS compliance, and settle abroad."
 ---
 
-This is an **API-only** cross-border collection rail. The buyer never sees an EximPe screen — they simply transfer rupees into a **Virtual Bank Account (VBA)**, and you assert the compliance details through the API.
+# Introduction
+
+This is an **API-only** cross-border collection rail. The buyer never sees an EximPe screen — they simply transfer rupees into a **Virtual Bank Account (VBA)**, and you assert the compliance details through the API. You build the product your customer sees; EximPe is the embedded India collection and settlement engine underneath.
+
+<CardGroup cols={3}>
+  <Card title="Issue a VBA" icon="building-columns" href="/integration-guide/v3/web-integration/virtual-accounts">
+    Give the buyer a local Indian account to transfer rupees into
+  </Card>
+  <Card title="Stay compliant" icon="shield-check" href="/integration-guide/v3/web-integration/lrs-compliance">
+    LRS eligibility, TCS, and documents, enforced through the API
+  </Card>
+  <Card title="Settle abroad" icon="money-bill-transfer" href="/api-reference/v3/settlement/list">
+    Cleared funds are converted and settled in your currency
+  </Card>
+</CardGroup>
 
 ## Roles
 

--- a/integration-guide/v3/web-integration/lrs-compliance.mdx
+++ b/integration-guide/v3/web-integration/lrs-compliance.mdx
@@ -3,6 +3,8 @@ title: "LRS & Compliance"
 description: "How the Liberalised Remittance Scheme works, the compliance rules EximPe enforces, the declarations the buyer affirms, TCS mechanics, and the education purpose codes and documents supported."
 ---
 
+# Introduction
+
 Most personal outward remittances from India fall under the **Liberalised Remittance Scheme (LRS)**, an RBI/FEMA framework. EximPe is an RBI-authorised **Payment Aggregator – Cross Border (PA-CB)**; a bank partner (an **Authorised Dealer**, or "AD bank") performs the actual outward remittance. Our APIs encode the LRS rules so you supply the remitter, the amount, and the documents — we enforce eligibility, tax, and the annual cap.
 
 ## How we work together

--- a/integration-guide/v3/web-integration/lrs-verification.mdx
+++ b/integration-guide/v3/web-integration/lrs-verification.mdx
@@ -3,6 +3,8 @@ title: "LRS Verification"
 description: "Make a collected payment compliant: verify the buyer's PAN, quote TCS, upload documents, and submit the remitter and purpose details under the Liberalised Remittance Scheme."
 ---
 
+# Introduction
+
 Every credit into a VBA creates a payment in **Action Required**. Under the **Liberalised Remittance Scheme (LRS)**, you make it compliant by asserting who the remitter is, why they are paying, and that the required tax and documents are in place. This guide walks the four LRS APIs in order.
 
 <Note>
@@ -13,9 +15,9 @@ Every credit into a VBA creates a payment in **Action Required**. Under the **Li
   New to the LRS rules, declarations, and required documents? Read [LRS & Compliance](/integration-guide/v3/web-integration/lrs-compliance) first — this page is the API walk-through.
 </Info>
 
-## Step 1 — Verify the buyer's PAN
+## Step 1: Verify the Buyer's PAN
 
-The remitter is identified by **PAN**, not by the bank sender on the credit. [Verify PAN](/api-reference/v3/lrs/verify-pan) checks the PAN against income-tax records and matches the name and date of birth. A verified PAN is the gateway to everything else.
+The remitter is identified by **PAN**, not by the bank sender on the credit. Verifying the PAN checks it against income-tax records and matches the name and date of birth. A verified PAN is the gateway to everything else, so do this first — a mismatch is a guaranteed bank rejection later.
 
 ```bash
 curl -X POST 'https://api-pacb-uat.eximpe.com/pg/pan/verify/' \
@@ -27,9 +29,13 @@ curl -X POST 'https://api-pacb-uat.eximpe.com/pg/pan/verify/' \
 
 A non-matching or rejected PAN returns `verified: false` with a `reason` (e.g. `NAME_MISMATCH`, `INOPERATIVE_PAN`) to resolve with the buyer before proceeding.
 
-## Step 2 — Quote the TCS
+<Card title="📚 API Reference" href="/api-reference/v3/lrs/verify-pan">
+  **Verify PAN API** — full request/response, statuses, and reasons.
+</Card>
 
-[Quote LRS Amount](/api-reference/v3/lrs/quote) returns the TCS due and the all-in total the buyer pays. For education from the buyer's own funds, TCS is **2% on the amount above ₹10,00,000** of the remitter's cumulative LRS this financial year — the first ₹10 lakh each year is TCS-free. This quotes against the LRS usage EximPe can see and reserves nothing.
+## Step 2: Quote the TCS
+
+Show the buyer a complete, tax-inclusive amount before they pay. The quote returns the TCS due and the all-in total to collect. For education from the buyer's own funds, TCS is **2% on the amount above ₹10,00,000** of the remitter's cumulative LRS this financial year — the first ₹10 lakh each year is TCS-free. This quotes against the LRS usage EximPe can see and reserves nothing, so you can re-quote freely.
 
 ```bash
 curl -X POST 'https://api-pacb-uat.eximpe.com/pg/lrs/quote/' \
@@ -41,9 +47,13 @@ curl -X POST 'https://api-pacb-uat.eximpe.com/pg/lrs/quote/' \
 
 The `purpose_code` must be one your settling entity is enabled for (its allowlist).
 
-## Step 3 — Upload supporting documents
+<Card title="📚 API Reference" href="/api-reference/v3/lrs/quote">
+  **Quote LRS Amount API** — TCS breakdown and threshold flags.
+</Card>
 
-Upload each supporting document with [Upload LRS Document](/api-reference/v3/lrs/upload-document) (`multipart/form-data`: `file` + `type`). Each upload returns a `ref` you pass in the next step. Documents are uploaded up front, decoupled from any payment.
+## Step 3: Upload Supporting Documents
+
+Upload each supporting document up front — decoupled from any payment. Each upload returns a `ref` you pass in the next step. This is a `multipart/form-data` request with a `file` and a `type`.
 
 ```bash
 curl -X POST 'https://api-pacb-uat.eximpe.com/pg/lrs/documents/' \
@@ -55,9 +65,13 @@ curl -X POST 'https://api-pacb-uat.eximpe.com/pg/lrs/documents/' \
 
 Document `type` values depend on the purpose code — e.g. `offer_letter`, `fee_invoice`, `passport`, `relationship_declaration`, `student_id_or_visa`. See the [document matrix](/integration-guide/v3/web-integration/lrs-compliance#purpose-codes-and-documents) for which documents each purpose code requires.
 
-## Step 4 — Submit verification details
+<Card title="📚 API Reference" href="/api-reference/v3/lrs/upload-document">
+  **Upload LRS Document API** — accepted types and validation.
+</Card>
 
-Finally, [Submit LRS Verification](/api-reference/v3/lrs/submit-verification) ties it together: the payment, remitter, purpose code, invoice, address, contact, declarations, collected TCS, and the document `ref`s. EximPe runs the checks (declarations, documents, sender-name match, TCS, money-match), posts the payment to the buyer's LRS counter, and advances it.
+## Step 4: Submit Verification Details
+
+Finally, submit the remaining details for the payment: the remitter, purpose code, invoice, address, contact, declarations, collected TCS, and the document `ref`s. EximPe runs the checks (declarations, documents, sender-name match, TCS, money-match), posts the payment to the buyer's LRS counter, and advances it.
 
 ```bash
 curl -X POST 'https://api-pacb-uat.eximpe.com/pg/lrs/verify/' \
@@ -71,13 +85,13 @@ curl -X POST 'https://api-pacb-uat.eximpe.com/pg/lrs/verify/' \
     "invoice": { "number": "INV-2025-0091", "date": "2025-07-01", "amount": 1200000 },
     "address": { "address1": "12 MG Road", "city": "Bengaluru", "state": "Karnataka", "pincode": "560001" },
     "contact": { "email": "john@example.com", "mobile": "9876543210" },
-    "tcs": 40000,
+    "tcs": 4000,
     "declarations": { "resident_in_india": true, "lrs": true, "tcs": true, "source_of_funds": true },
     "documents": [ { "type": "offer_letter", "ref": "<ref-from-step-3>" } ]
   }'
 ```
 
-### Result statuses
+The response reports the resulting state:
 
 | `status` | Meaning |
 | :--- | :--- |
@@ -93,6 +107,10 @@ curl -X POST 'https://api-pacb-uat.eximpe.com/pg/lrs/verify/' \
   Topping up an earlier payment? Pass `linked_payment_id` and a `reason` (`REMAINING_AMOUNT` or `TCS_PAYMENT`) on submit. `reason` is only valid together with `linked_payment_id`.
 </Info>
 
-## After submission
+<Card title="📚 API Reference" href="/api-reference/v3/lrs/submit-verification">
+  **Submit LRS Verification API** — full payload, checks, and result statuses.
+</Card>
+
+## After Submission
 
 Once the payment clears review, funds are settled to the beneficiary abroad. Track settlement via the [Settlement APIs](/api-reference/v3/settlement/list) and the [Payment Settled](/api-reference/v3/webhooks/payment-settled) webhook.

--- a/integration-guide/v3/web-integration/virtual-accounts.mdx
+++ b/integration-guide/v3/web-integration/virtual-accounts.mdx
@@ -1,17 +1,56 @@
 ---
 title: "Virtual Bank Accounts"
-description: "Issue a Virtual Bank Account (VBA) for a settling entity, receive rupee credits, and simulate transfers in the sandbox."
+description: "Collect rupees from Indian buyers via local bank transfers into a dedicated virtual account — no SWIFT, no forex hassle for your customers."
 ---
 
-A **Virtual Bank Account (VBA)** is a persistent Indian bank account (account number + IFSC) issued to a settling entity. Buyers transfer rupees into it, and every credit that lands creates a payment you then verify for LRS.
+# Introduction
+
+Collecting money from India is hard. Your buyers face SWIFT fees, complex forex processes, and unfamiliar international wire workflows — all of which create friction, delay payments, and increase drop-off.
+
+Virtual Bank Accounts (VBAs) solve this by giving a settling entity a dedicated Indian bank account. The buyer simply transfers rupees using methods they already know and trust — NEFT, RTGS, or IMPS — just like paying any local vendor. EximPe handles the regulatory compliance, currency conversion, and settlement to your preferred currency.
+
+<CardGroup cols={3}>
+  <Card title="Local for the buyer" icon="building-columns" href="#how-it-works">
+    Buyers pay by familiar domestic transfer — no SWIFT, no intermediary banks
+  </Card>
+  <Card title="Real-time tracking" icon="bolt" href="#step-3-track-payments">
+    Instant webhook notifications on every incoming credit
+  </Card>
+  <Card title="Compliance built in" icon="shield-check" href="/integration-guide/v3/web-integration/lrs-compliance">
+    LRS eligibility, TCS, and documents are handled through the API
+  </Card>
+</CardGroup>
+
+## How It Works
+
+1. **You get an Indian bank account** — EximPe issues a virtual bank account with a unique account number and IFSC for the settling entity.
+2. **Your buyer pays locally** — they initiate a standard domestic transfer (NEFT, RTGS, or IMPS) to the VBA. No international wires, no SWIFT.
+3. **You get notified instantly** — EximPe creates a payment from the credit and sends a real-time webhook.
+4. **Compliance is handled** — you assert the LRS details (remitter, purpose, documents) via API to meet RBI's cross-border rules.
+5. **Settlement in your currency** — cleared funds are converted and settled to your international bank account.
 
 <Note>
-  A VBA is **not** bound to a single buyer — it can receive credits from many remitters. From v2.0.0 onward, a settling entity can have multiple ACTIVE VBAs at once.
+  A VBA is **not** bound to a single buyer — it can receive credits from many remitters. From v2.0.0 onwards, a settling entity can have multiple **ACTIVE** VBAs at once.
 </Note>
 
-## Create a VBA
+## Prerequisites
 
-Use [Create VBA](/api-reference/v3/vba/create). The account name, email, phone, and `virtual_account_id` are derived from the merchant account, so the request body is minimal — you optionally supply lock rules.
+Before you begin, ensure you have:
+
+- **Merchant account**: an active, approved settling entity (sub-merchant or direct merchant) with the VBA feature enabled.
+- **Credentials**: your `X-Client-ID` and `X-Client-Secret` (PSP callers also send `X-Merchant-ID` for the settling sub-merchant).
+- **Webhook URL**: a secure endpoint to receive VBA payment notifications, configured on your credentials.
+
+## Integration Steps
+
+1. **Create VBA** — issue a virtual bank account for the settling entity.
+2. **Share account details** — pass the account number and IFSC to the buyer.
+3. **Track payments** — list payments or fetch by UTR, or use webhooks for real-time updates.
+4. **Simulate a transfer (sandbox)** — test the end-to-end flow without a real bank transfer.
+
+## Step 1: Create VBA
+
+Create a Virtual Bank Account for the settling entity. The account name, email, phone, and `virtual_account_id` are derived from the merchant account, so the request body is minimal — you optionally supply lock rules.
 
 ```bash
 curl -X POST 'https://api-pacb-uat.eximpe.com/pg/vba/' \
@@ -23,53 +62,49 @@ curl -X POST 'https://api-pacb-uat.eximpe.com/pg/vba/' \
   -d '{}'
 ```
 
-The response carries the `vba_account_number`, `vba_ifsc`, `vba_bank_code`, `vba_status`, and `vba_provider`. **Share the account number and IFSC with the buyer** — that is where they transfer the rupees.
+You can optionally lock a VBA at creation time:
+
+- **Remitter lock** — restrict the VBA to accept transfers only from a specific list of remitter bank accounts (each identified by account number and IFSC).
+- **Amount lock** — restrict the VBA to accept transfers within an amount range.
+
+Both locks are optional and independent; when omitted they return as `null` and impose no restriction.
+
+<Card title="📚 API Reference" href="/api-reference/v3/vba/create">
+  **Create VBA API** — full request/response and error codes.
+</Card>
+
+## Step 2: Share Account Details
+
+The response returns `vba_account_number`, `vba_ifsc`, `vba_bank_code`, `vba_status`, and `vba_provider`. Share the account number and IFSC with the buyer so they can initiate a NEFT, RTGS, or IMPS transfer into the virtual account.
 
 <Note>
   For ICICI-provider VBAs, the account number is a 16-character number in a fixed pattern: the `INRACC` prefix + a 3-character partner shortcode + a 7-digit identifier — e.g. `INRACCNEX1234567`. The IFSC is fixed per client code.
 </Note>
 
-### Optional lock rules
+## Step 3: Track Payments
 
-You can restrict what a VBA will accept:
-
-- **Remitter lock** — accept transfers only from specific remitter account(s). Omit to accept from any remitter.
-- **Amount lock** — restrict to specific amount(s). Omit to accept any amount.
-
-Both are independent and optional; when omitted they return as `null` and impose no restriction.
-
-## List & read VBAs
-
-<CardGroup cols={2}>
-  <Card title="List VBAs" icon="list" href="/api-reference/v3/vba/list">
-    Paginated list for the merchant, filterable by `vba_status` and `vba_provider`.
-  </Card>
-  <Card title="Get VBA" icon="magnifying-glass" href="/api-reference/v3/vba/get">
-    Fetch a single VBA by `virtual_account_id`.
-  </Card>
-  <Card title="List Payments" icon="arrow-down-to-line" href="/api-reference/v3/vba/list-payments">
-    Payments (credits) collected on a VBA.
-  </Card>
-  <Card title="Payment by UTR" icon="hashtag" href="/api-reference/v3/vba/get-payment-by-utr">
-    Look up a single credit by its bank UTR.
-  </Card>
-</CardGroup>
-
-## Receiving a credit
-
-When a buyer transfers rupees into the VBA:
+When a credit lands in the VBA, EximPe creates a payment and sends webhooks to your registered URL so you can process it in real time:
 
 1. EximPe records the **credit** (amount, sender account + IFSC, payer name, UTR).
 2. A payment is created in **Action Required** — the remitter's PAN is not derived from the credit.
-3. You receive a payment webhook. Proceed to [LRS Verification](/integration-guide/v3/web-integration/lrs-verification) to make it compliant.
+3. You receive a payment webhook. Proceed to [LRS Verification](/integration-guide/v3/web-integration/lrs-verification) to make the payment compliant.
 
 <Warning>
   The sender bank account on a credit is the **payer instrument**, not the **remitter identity**. You must assert the remitter (by PAN) during LRS verification — do not assume the bank sender is the PAN holder.
 </Warning>
 
-## Simulate a transfer (Sandbox)
+<CardGroup cols={2}>
+  <Card title="📚 List VBA Payments" href="/api-reference/v3/vba/list-payments">
+    Paginated list of payments collected on a VBA.
+  </Card>
+  <Card title="📚 Get Payment by UTR" href="/api-reference/v3/vba/get-payment-by-utr">
+    Fetch a single credit by its bank UTR.
+  </Card>
+</CardGroup>
 
-Real bank credits can't be produced on demand in a test environment, so use [Simulate VBA Transfer](/api-reference/v3/vba/simulate-transfer) to drive a credit into a VBA. It works for both **Cashfree** and **ICICI** VBAs (for ICICI it runs the real credit-posting processor), and is **sandbox-only** (403 in production). The `utr` must be unique across simulations.
+## Step 4: Simulate a Transfer (Sandbox)
+
+In the sandbox environment, you can simulate an incoming bank transfer to a VBA to test the end-to-end flow — webhooks, payment creation, and the LRS flow — without a real bank transfer. It works for both **Cashfree** and **ICICI** VBAs (for ICICI it runs the real credit-posting processor). The `utr` must be unique across simulations.
 
 ```bash
 curl -X POST 'https://api-pacb-uat.eximpe.com/pg/vba/simulate-transfer/' \
@@ -90,7 +125,22 @@ curl -X POST 'https://api-pacb-uat.eximpe.com/pg/vba/simulate-transfer/' \
   }'
 ```
 
-This creates a payment in **Action Required** and fires the payment webhook — exactly as a real credit would — so you can exercise the full LRS flow end-to-end.
+<Warning>This endpoint is available only in the sandbox environment, not in production.</Warning>
+
+<Card title="📚 API Reference" href="/api-reference/v3/vba/simulate-transfer">
+  **Simulate VBA Transfer API** — simulate a payment to a VBA in sandbox.
+</Card>
+
+## Managing VBAs
+
+EximPe provides APIs to manage the lifecycle of your virtual bank accounts:
+
+- **[Create VBA](/api-reference/v3/vba/create)** — create a new VBA, optionally with remitter and/or amount locks.
+- **[List VBAs](/api-reference/v3/vba/list)** — paginated list, filterable by `vba_status` and `vba_provider`.
+- **[Get VBA Details](/api-reference/v3/vba/get)** — fetch details of an existing VBA.
+- **[List VBA Payments](/api-reference/v3/vba/list-payments)** — list all payments for a VBA.
+- **[Get Payment by UTR](/api-reference/v3/vba/get-payment-by-utr)** — get a single payment by UTR.
+- **[Simulate VBA Transfer](/api-reference/v3/vba/simulate-transfer)** — simulate an incoming transfer to a VBA in sandbox.
 
 <Info>
   Next: make the collected payment compliant in [LRS Verification](/integration-guide/v3/web-integration/lrs-verification).


### PR DESCRIPTION
Follow-up to #60 — this commit was pushed to the #60 branch after it merged, so it's re-landed here.

Matches the V2 guide voice and conventions on the V3 web-integration pages:
- **`# Introduction`** opening with a relatable framing on each page
- **benefit `<CardGroup>`** near the top
- **"Step N:"** walkthrough headings and **"How It Works"** numbered lists
- **"📚 API Reference"** link cards to the api-reference (instead of plain inline links)
- **Prerequisites / Integration Steps / Managing VBAs** sections on the Virtual Bank Accounts page (mirrors V2's VBA page)

Also fixes the last stray TCS example (`lrs-verification` submit curl `tcs 40000 → 4000`).

Pages: `virtual-accounts`, `lrs-verification`, `collection-overview`, `lrs-compliance`. No API or nav changes.