### PR TITLE
docs: update card and webhook payload schemas for v1/v2

### DIFF
--- a/api-reference/v1/webhooks/payment-failed.mdx
+++ b/api-reference/v1/webhooks/payment-failed.mdx
@@ -51,14 +51,20 @@ Compute `HMAC-SHA256(encryption_key, raw_body)` where `raw_body` is the exact UT
     "version": "1.0",
     "sequence_number": "e40552bf-ed12-4f35-9a97-162d97e6fa34",
     "data": {
-        "status": "failed",
+        "utr": null,
+        "amount": 1000,
+        "status": "FAILED",
         "message": "Cancelled by user",
-        "mop_type": "upi",
+        "mop_type": "UPI",
         "order_id": "OD3376378679",
         "payment_id": "PR6938527534",
-        "bank_ref_num": "OD3376378679-PR6938527534",
-        "payment_completed_at": "2025-06-24T12:30:44.000000Z",
-        "subscription": "SUB123456"
+        "bank_ref_num": null,
+        "extended_status": "FAILED",
+        "payment_message": null,
+        "subscription_id": null,
+        "virtual_account_id": null,
+        "payment_completed_at": null,
+        "merchant_reference_id": "S2SIOAW7W4"
     }
 }
 ```
@@ -115,6 +121,12 @@ Compute `HMAC-SHA256(encryption_key, raw_body)` where `raw_body` is the exact UT
       **Example**: `"UPI"`
     </ParamField>
 
+    <ParamField path="data.amount" type="number" required>
+      Payment amount
+      
+      **Example**: `1000`
+    </ParamField>
+
     <ParamField path="data.order_id" type="string" required>
       Order ID
       
@@ -127,16 +139,44 @@ Compute `HMAC-SHA256(encryption_key, raw_body)` where `raw_body` is the exact UT
       **Example**: `"PR6938527534"`
     </ParamField>
 
-    <ParamField path="data.bank_ref_num" type="string" required>
-      Bank reference number
+    <ParamField path="data.bank_ref_num" type="string">
+      Bank reference number; typically null for failed payments
       
-      **Example**: `"OD3376378679-PR6938527534"`
+      **Example**: `null`
     </ParamField>
 
-    <ParamField path="data.payment_completed_at" type="string" required>
-      ISO 8601 payment completion timestamp
+    <ParamField path="data.extended_status" type="string" required>
+      Detailed status code for the payment
       
-      **Example**: `"2025-06-24T12:30:44.000000Z"`
+      **Example**: `"FAILED"`
+    </ParamField>
+
+    <ParamField path="data.payment_message" type="string">
+      Additional processor-level message; may be null
+    </ParamField>
+
+    <ParamField path="data.utr" type="string">
+      UTR of the payment (if any); may be null
+    </ParamField>
+
+    <ParamField path="data.subscription_id" type="string">
+      Subscription ID if this payment is linked to a subscription mandate; otherwise null
+    </ParamField>
+
+    <ParamField path="data.virtual_account_id" type="string">
+      Virtual account ID if this payment is linked to a VBA; otherwise null
+    </ParamField>
+
+    <ParamField path="data.merchant_reference_id" type="string" required>
+      Your reference ID for the order
+      
+      **Example**: `"S2SIOAW7W4"`
+    </ParamField>
+
+    <ParamField path="data.payment_completed_at" type="string">
+      ISO 8601 payment completion timestamp; null for failed payments
+      
+      **Example**: `null`
     </ParamField>
   </Tab>
 </Tabs>

--- a/api-reference/v1/webhooks/payment-refunded.mdx
+++ b/api-reference/v1/webhooks/payment-refunded.mdx
@@ -51,11 +51,15 @@ Compute `HMAC-SHA256(encryption_key, raw_body)` where `raw_body` is the exact UT
     "data": {
         "refunds": [
             {
-                "payment_request_id": "PR7485664995",
+                "bank_arn": "arn",
+                "comments": "Refund processed successfully",
                 "order_id": "OD6085456489",
                 "refund_id": "RF2684785771",
-                "amount": 1000,
-                "bank_arn": "arn"
+                "payment_id": "PR7485664995",
+                "refund_amount": 1000,
+                "order_reference_id": "REF6085456489",
+                "refund_completed_at": "2025-06-24T12:30:44.000000Z",
+                "refund_reference_id": "c82df8dedf844acaa497ece9126a967e"
             }
         ]
     }
@@ -98,8 +102,8 @@ Compute `HMAC-SHA256(encryption_key, raw_body)` where `raw_body` is the exact UT
       Array of refund objects containing the refund information
     </ParamField>
 
-    <ParamField path="data.refunds[].payment_request_id" type="string" required>
-      Original payment request ID that was refunded
+    <ParamField path="data.refunds[].payment_id" type="string" required>
+      Original payment ID that was refunded
       
       **Example**: `"PR7485664995"`
     </ParamField>
@@ -116,7 +120,7 @@ Compute `HMAC-SHA256(encryption_key, raw_body)` where `raw_body` is the exact UT
       **Example**: `"RF2684785771"`
     </ParamField>
 
-    <ParamField path="data.refunds[].amount" type="number" required>
+    <ParamField path="data.refunds[].refund_amount" type="number" required>
       Refund amount
       
       **Example**: `1000`
@@ -126,6 +130,30 @@ Compute `HMAC-SHA256(encryption_key, raw_body)` where `raw_body` is the exact UT
       Bank ARN (Acquirer Reference Number) - may be null
       
       **Example**: `"arn"`
+    </ParamField>
+
+    <ParamField path="data.refunds[].comments" type="string">
+      Human-readable note describing the refund outcome
+      
+      **Example**: `"Refund processed successfully"`
+    </ParamField>
+
+    <ParamField path="data.refunds[].order_reference_id" type="string">
+      Your reference ID for the order associated with the refund
+      
+      **Example**: `"REF6085456489"`
+    </ParamField>
+
+    <ParamField path="data.refunds[].refund_completed_at" type="string">
+      ISO 8601 timestamp when the refund completed
+      
+      **Example**: `"2025-06-24T12:30:44.000000Z"`
+    </ParamField>
+
+    <ParamField path="data.refunds[].refund_reference_id" type="string">
+      Unique reference ID for this refund transaction
+      
+      **Example**: `"c82df8dedf844acaa497ece9126a967e"`
     </ParamField>
   </Tab>
 </Tabs>

--- a/api-reference/v1/webhooks/payment-successful.mdx
+++ b/api-reference/v1/webhooks/payment-successful.mdx
@@ -51,14 +51,20 @@ Compute `HMAC-SHA256(encryption_key, raw_body)` where `raw_body` is the exact UT
     "version": "1.0",
     "sequence_number": "e40552bf-ed12-4f35-9a97-162d97e6fa34",
     "data": {
-        "status": "captured",
-        "message": "Payment successful",
-        "mop_type": "upi",
+        "utr": null,
+        "amount": 1000,
+        "status": "CAPTURED",
+        "message": "Payment Captured",
+        "mop_type": "UPI",
         "order_id": "OD3376378679",
         "payment_id": "PR6938527534",
         "bank_ref_num": "OD3376378679-PR6938527534",
+        "extended_status": "SUCCESS",
+        "payment_message": null,
+        "subscription_id": null,
+        "virtual_account_id": null,
         "payment_completed_at": "2025-06-24T12:30:44.000000Z",
-        "subscription": "SUB123456"
+        "merchant_reference_id": "S2SICR1QPJ"
     }
 }
 ```
@@ -106,13 +112,19 @@ Compute `HMAC-SHA256(encryption_key, raw_body)` where `raw_body` is the exact UT
     <ParamField path="data.message" type="string" required>
       Additional message or note
       
-      **Example**: `"Payment successful"`
+      **Example**: `"Payment Captured"`
     </ParamField>
 
     <ParamField path="data.mop_type" type="string" required>
       Method of payment type
       
       **Example**: `"UPI"`
+    </ParamField>
+
+    <ParamField path="data.amount" type="number" required>
+      Payment amount
+      
+      **Example**: `1000`
     </ParamField>
 
     <ParamField path="data.order_id" type="string" required>
@@ -127,10 +139,38 @@ Compute `HMAC-SHA256(encryption_key, raw_body)` where `raw_body` is the exact UT
       **Example**: `"PR6938527534"`
     </ParamField>
 
-    <ParamField path="data.bank_ref_num" type="string" required>
-      Bank reference number
+    <ParamField path="data.bank_ref_num" type="string">
+      Bank reference number; may be null
       
       **Example**: `"OD3376378679-PR6938527534"`
+    </ParamField>
+
+    <ParamField path="data.extended_status" type="string" required>
+      Detailed status code for the payment
+      
+      **Example**: `"SUCCESS"`
+    </ParamField>
+
+    <ParamField path="data.payment_message" type="string">
+      Additional processor-level message; may be null
+    </ParamField>
+
+    <ParamField path="data.utr" type="string">
+      UTR of the payment (if any); may be null
+    </ParamField>
+
+    <ParamField path="data.subscription_id" type="string">
+      Subscription ID if this payment is linked to a subscription mandate; otherwise null
+    </ParamField>
+
+    <ParamField path="data.virtual_account_id" type="string">
+      Virtual account ID if this payment is linked to a VBA; otherwise null
+    </ParamField>
+
+    <ParamField path="data.merchant_reference_id" type="string" required>
+      Your reference ID for the order
+      
+      **Example**: `"S2SICR1QPJ"`
     </ParamField>
 
     <ParamField path="data.payment_completed_at" type="string" required>

--- a/api-reference/v1/webhooks/refund-failed.mdx
+++ b/api-reference/v1/webhooks/refund-failed.mdx
@@ -53,7 +53,9 @@ Compute `HMAC-SHA256(encryption_key, raw_body)` where `raw_body` is the exact UT
                 "refund_id": "RF9013486220",
                 "payment_id": "PR5527901834",
                 "refund_amount": 250,
-                "refund_completed_at": null
+                "order_reference_id": "REF8842170653",
+                "refund_completed_at": null,
+                "refund_reference_id": "a3f5c7d19e8b4c62b1d0f4e8a6c9d3b7"
             }
         ]
     },
@@ -136,10 +138,22 @@ Compute `HMAC-SHA256(encryption_key, raw_body)` where `raw_body` is the exact UT
       **Example**: `null`
     </ParamField>
 
+    <ParamField path="data.refunds[].order_reference_id" type="string">
+      Your reference ID for the order associated with the refund
+      
+      **Example**: `"REF8842170653"`
+    </ParamField>
+
     <ParamField path="data.refunds[].refund_completed_at" type="string">
       Timestamp when the refund completed - `null` for a failed refund
       
       **Example**: `null`
+    </ParamField>
+
+    <ParamField path="data.refunds[].refund_reference_id" type="string">
+      Unique reference ID for this refund transaction
+      
+      **Example**: `"a3f5c7d19e8b4c62b1d0f4e8a6c9d3b7"`
     </ParamField>
   </Tab>
 </Tabs>

--- a/api-reference/v1/webhooks/refund-status-update.mdx
+++ b/api-reference/v1/webhooks/refund-status-update.mdx
@@ -54,7 +54,9 @@ Compute `HMAC-SHA256(encryption_key, raw_body)` where `raw_body` is the exact UT
                 "payment_id": "PR6271908354",
                 "refund_amount": 320,
                 "refund_status": "PROCESSING",
-                "refund_completed_at": null
+                "order_reference_id": "REF5128740396",
+                "refund_completed_at": null,
+                "refund_reference_id": "f4d8b2e6a1c94b7fa0e3d6c9b8a5f2e1"
             }
         ]
     },
@@ -143,10 +145,22 @@ Compute `HMAC-SHA256(encryption_key, raw_body)` where `raw_body` is the exact UT
       **Example**: `null`
     </ParamField>
 
+    <ParamField path="data.refunds[].order_reference_id" type="string">
+      Your reference ID for the order associated with the refund
+      
+      **Example**: `"REF5128740396"`
+    </ParamField>
+
     <ParamField path="data.refunds[].refund_completed_at" type="string">
       Timestamp when the refund completed - `null` while the refund is still in progress
       
       **Example**: `null`
+    </ParamField>
+
+    <ParamField path="data.refunds[].refund_reference_id" type="string">
+      Unique reference ID for this refund transaction
+      
+      **Example**: `"f4d8b2e6a1c94b7fa0e3d6c9b8a5f2e1"`
     </ParamField>
   </Tab>
 </Tabs>

--- a/api-reference/v2/webhooks/payment-failed.mdx
+++ b/api-reference/v2/webhooks/payment-failed.mdx
@@ -61,10 +61,15 @@ Compute `HMAC-SHA256(encryption_key, raw_body)` where `raw_body` is the exact UT
     "status": "FAILED",
     "message": "Payment declined by bank",
     "mop_type": "CARD",
-    "bank_ref_num": "",
+    "amount": 1000,
+    "bank_ref_num": null,
+    "extended_status": "FAILED",
+    "payment_message": null,
     "payment_completed_at": null,
     "utr": null,
-    "virtual_account_id": null
+    "virtual_account_id": null,
+    "subscription_id": null,
+    "merchant_reference_id": "S2SIOAW7W4"
   }
 }
 ```
@@ -88,7 +93,7 @@ Compute `HMAC-SHA256(encryption_key, raw_body)` where `raw_body` is the exact UT
     </ParamField>
 
     <ParamField path="version" type="string" required>
-      Envelope version (e.g. "1.0")
+      Envelope version (e.g. "2.0.0")
     </ParamField>
 
     <ParamField path="sequence_number" type="string" required>
@@ -98,7 +103,7 @@ Compute `HMAC-SHA256(encryption_key, raw_body)` where `raw_body` is the exact UT
     </ParamField>
 
     <ParamField path="data" type="object" required>
-      Payment request details (payment_id, order_id, status, message, mop_type, bank_ref_num, payment_completed_at, utr, virtual_account_id)
+      Payment request details (payment_id, order_id, status, message, mop_type, amount, bank_ref_num, extended_status, payment_message, payment_completed_at, utr, virtual_account_id, subscription_id, merchant_reference_id)
     </ParamField>
   </Tab>
 
@@ -133,28 +138,54 @@ Compute `HMAC-SHA256(encryption_key, raw_body)` where `raw_body` is the exact UT
       **Example**: `"CARD"`
     </ParamField>
 
-    <ParamField path="data.bank_ref_num" type="string" required>
-      Bank reference number (if any); may be empty string
+    <ParamField path="data.amount" type="number" required>
+      Payment amount
       
-      **Example**: `""`
+      **Example**: `1000`
     </ParamField>
 
-    <ParamField path="data.payment_completed_at" type="string" required>
+    <ParamField path="data.bank_ref_num" type="string">
+      Bank reference number (if any); typically null for failed payments
+      
+      **Example**: `null`
+    </ParamField>
+
+    <ParamField path="data.extended_status" type="string" required>
+      Detailed status code for the payment
+      
+      **Example**: `"FAILED"`
+    </ParamField>
+
+    <ParamField path="data.payment_message" type="string">
+      Additional processor-level message; may be null
+    </ParamField>
+
+    <ParamField path="data.payment_completed_at" type="string">
       ISO 8601 datetime when payment completed; may be null for failed payments
       
       **Example**: `null`
     </ParamField>
 
-    <ParamField path="data.utr" type="string" required>
+    <ParamField path="data.utr" type="string">
       UTR of the payment (if any); may be empty or null
       
       **Example**: `null`
     </ParamField>
 
-    <ParamField path="data.virtual_account_id" type="string" required>
+    <ParamField path="data.virtual_account_id" type="string">
       Virtual account ID of the MerchantVBA (if this payment is linked to a VBA); otherwise null
       
       **Example**: `null`
+    </ParamField>
+
+    <ParamField path="data.subscription_id" type="string">
+      Subscription ID if this payment is linked to a subscription mandate; otherwise null
+    </ParamField>
+
+    <ParamField path="data.merchant_reference_id" type="string" required>
+      Your reference ID for the order
+      
+      **Example**: `"S2SIOAW7W4"`
     </ParamField>
   </Tab>
 </Tabs>

--- a/api-reference/v2/webhooks/payment-refunded.mdx
+++ b/api-reference/v2/webhooks/payment-refunded.mdx
@@ -51,11 +51,15 @@ Compute `HMAC-SHA256(encryption_key, raw_body)` where `raw_body` is the exact UT
     "data": {
         "refunds": [
             {
-                "payment_request_id": "PR7485664995",
+                "bank_arn": "arn",
+                "comments": "Refund processed successfully",
                 "order_id": "OD6085456489",
                 "refund_id": "RF2684785771",
-                "amount": 1000,
-                "bank_arn": "arn"
+                "payment_id": "PR7485664995",
+                "refund_amount": 1000,
+                "order_reference_id": "REF6085456489",
+                "refund_completed_at": "2025-06-24T12:30:44.000000Z",
+                "refund_reference_id": "c82df8dedf844acaa497ece9126a967e"
             }
         ]
     }
@@ -98,8 +102,8 @@ Compute `HMAC-SHA256(encryption_key, raw_body)` where `raw_body` is the exact UT
       Array of refund objects containing the refund information
     </ParamField>
 
-    <ParamField path="data.refunds[].payment_request_id" type="string" required>
-      Original payment request ID that was refunded
+    <ParamField path="data.refunds[].payment_id" type="string" required>
+      Original payment ID that was refunded
       
       **Example**: `"PR7485664995"`
     </ParamField>
@@ -116,7 +120,7 @@ Compute `HMAC-SHA256(encryption_key, raw_body)` where `raw_body` is the exact UT
       **Example**: `"RF2684785771"`
     </ParamField>
 
-    <ParamField path="data.refunds[].amount" type="number" required>
+    <ParamField path="data.refunds[].refund_amount" type="number" required>
       Refund amount
       
       **Example**: `1000`
@@ -126,6 +130,30 @@ Compute `HMAC-SHA256(encryption_key, raw_body)` where `raw_body` is the exact UT
       Bank ARN (Acquirer Reference Number) - may be null
       
       **Example**: `"arn"`
+    </ParamField>
+
+    <ParamField path="data.refunds[].comments" type="string">
+      Human-readable note describing the refund outcome
+      
+      **Example**: `"Refund processed successfully"`
+    </ParamField>
+
+    <ParamField path="data.refunds[].order_reference_id" type="string">
+      Your reference ID for the order associated with the refund
+      
+      **Example**: `"REF6085456489"`
+    </ParamField>
+
+    <ParamField path="data.refunds[].refund_completed_at" type="string">
+      ISO 8601 timestamp when the refund completed
+      
+      **Example**: `"2025-06-24T12:30:44.000000Z"`
+    </ParamField>
+
+    <ParamField path="data.refunds[].refund_reference_id" type="string">
+      Unique reference ID for this refund transaction
+      
+      **Example**: `"c82df8dedf844acaa497ece9126a967e"`
     </ParamField>
   </Tab>
 </Tabs>

--- a/api-reference/v2/webhooks/payment-successful.mdx
+++ b/api-reference/v2/webhooks/payment-successful.mdx
@@ -60,13 +60,17 @@ Compute `HMAC-SHA256(encryption_key, raw_body)` where `raw_body` is the exact UT
     "payment_id": "770e8400-e29b-41d4-a716-446655440002",
     "order_id": "660e8400-e29b-41d4-a716-446655440001",
     "status": "CAPTURED",
-    "message": "Payment successful",
+    "message": "Payment Captured",
     "mop_type": "VBA_TRANSFER",
+    "amount": 1000,
     "bank_ref_num": "BANKREF123",
+    "extended_status": "SUCCESS",
+    "payment_message": null,
     "payment_completed_at": "2025-02-12T10:29:55.000000Z",
     "utr": "UTR123456",
     "virtual_account_id": "USER09",
-    "subscription_id": null
+    "subscription_id": null,
+    "merchant_reference_id": "S2SICR1QPJ"
   }
 }
 ```
@@ -100,7 +104,7 @@ Compute `HMAC-SHA256(encryption_key, raw_body)` where `raw_body` is the exact UT
     </ParamField>
 
     <ParamField path="data" type="object" required>
-      Payment request details (payment_id, order_id, status, message, mop_type, bank_ref_num, payment_completed_at, utr, virtual_account_id, subscription_id)
+      Payment request details (payment_id, order_id, status, message, mop_type, amount, bank_ref_num, extended_status, payment_message, payment_completed_at, utr, virtual_account_id, subscription_id, merchant_reference_id)
     </ParamField>
   </Tab>
 
@@ -126,7 +130,7 @@ Compute `HMAC-SHA256(encryption_key, raw_body)` where `raw_body` is the exact UT
     <ParamField path="data.message" type="string" required>
       Status message from the payment
       
-      **Example**: `"Payment successful"`
+      **Example**: `"Payment Captured"`
     </ParamField>
 
     <ParamField path="data.mop_type" type="string" required>
@@ -135,10 +139,26 @@ Compute `HMAC-SHA256(encryption_key, raw_body)` where `raw_body` is the exact UT
       **Example**: `"VBA_TRANSFER"`
     </ParamField>
 
-    <ParamField path="data.bank_ref_num" type="string" required>
-      Bank reference number (if any)
+    <ParamField path="data.amount" type="number" required>
+      Payment amount
+      
+      **Example**: `1000`
+    </ParamField>
+
+    <ParamField path="data.bank_ref_num" type="string">
+      Bank reference number; may be null
       
       **Example**: `"BANKREF123"`
+    </ParamField>
+
+    <ParamField path="data.extended_status" type="string" required>
+      Detailed status code for the payment
+      
+      **Example**: `"SUCCESS"`
+    </ParamField>
+
+    <ParamField path="data.payment_message" type="string">
+      Additional processor-level message; may be null
     </ParamField>
 
     <ParamField path="data.payment_completed_at" type="string" required>
@@ -147,16 +167,26 @@ Compute `HMAC-SHA256(encryption_key, raw_body)` where `raw_body` is the exact UT
       **Example**: `"2025-02-12T10:29:55.000000Z"`
     </ParamField>
 
-    <ParamField path="data.utr" type="string" required>
+    <ParamField path="data.utr" type="string">
       UTR of the payment (if any); may be empty or null
       
       **Example**: `"UTR123456"`
     </ParamField>
 
-    <ParamField path="data.virtual_account_id" type="string" required>
+    <ParamField path="data.virtual_account_id" type="string">
       Virtual account ID of the MerchantVBA (if this payment is linked to a VBA); otherwise null
       
       **Example**: `"USER09"`
+    </ParamField>
+
+    <ParamField path="data.subscription_id" type="string">
+      Subscription ID if this payment is linked to a subscription mandate; otherwise null
+    </ParamField>
+
+    <ParamField path="data.merchant_reference_id" type="string" required>
+      Your reference ID for the order
+      
+      **Example**: `"S2SICR1QPJ"`
     </ParamField>
   </Tab>
 </Tabs>

--- a/api-reference/v2/webhooks/refund-failed.mdx
+++ b/api-reference/v2/webhooks/refund-failed.mdx
@@ -53,7 +53,9 @@ Compute `HMAC-SHA256(encryption_key, raw_body)` where `raw_body` is the exact UT
                 "refund_id": "RF4762038159",
                 "payment_id": "PR6018394572",
                 "refund_amount": 1499,
-                "refund_completed_at": null
+                "order_reference_id": "REF3391756028",
+                "refund_completed_at": null,
+                "refund_reference_id": "e6b2a9c4d1f847b3a8e2c5d9f0a7b1c6"
             }
         ]
     },
@@ -136,10 +138,22 @@ Compute `HMAC-SHA256(encryption_key, raw_body)` where `raw_body` is the exact UT
       **Example**: `null`
     </ParamField>
 
+    <ParamField path="data.refunds[].order_reference_id" type="string">
+      Your reference ID for the order associated with the refund
+      
+      **Example**: `"REF3391756028"`
+    </ParamField>
+
     <ParamField path="data.refunds[].refund_completed_at" type="string">
       Timestamp when the refund completed - `null` for a failed refund
       
       **Example**: `null`
+    </ParamField>
+
+    <ParamField path="data.refunds[].refund_reference_id" type="string">
+      Unique reference ID for this refund transaction
+      
+      **Example**: `"e6b2a9c4d1f847b3a8e2c5d9f0a7b1c6"`
     </ParamField>
   </Tab>
 </Tabs>

--- a/api-reference/v2/webhooks/refund-status-update.mdx
+++ b/api-reference/v2/webhooks/refund-status-update.mdx
@@ -54,7 +54,9 @@ Compute `HMAC-SHA256(encryption_key, raw_body)` where `raw_body` is the exact UT
                 "payment_id": "PR8054316729",
                 "refund_amount": 2750,
                 "refund_status": "PROCESSING",
-                "refund_completed_at": null
+                "order_reference_id": "REF9472058163",
+                "refund_completed_at": null,
+                "refund_reference_id": "b7c1d5f8a2e94c60b3d8e1f4a9c6d2b5"
             }
         ]
     },
@@ -143,10 +145,22 @@ Compute `HMAC-SHA256(encryption_key, raw_body)` where `raw_body` is the exact UT
       **Example**: `null`
     </ParamField>
 
+    <ParamField path="data.refunds[].order_reference_id" type="string">
+      Your reference ID for the order associated with the refund
+      
+      **Example**: `"REF9472058163"`
+    </ParamField>
+
     <ParamField path="data.refunds[].refund_completed_at" type="string">
       Timestamp when the refund completed - `null` while the refund is still in progress
       
       **Example**: `null`
+    </ParamField>
+
+    <ParamField path="data.refunds[].refund_reference_id" type="string">
+      Unique reference ID for this refund transaction
+      
+      **Example**: `"b7c1d5f8a2e94c60b3d8e1f4a9c6d2b5"`
     </ParamField>
   </Tab>
 </Tabs>

--- a/integration-guide/v1/web-integration/payment-links.mdx
+++ b/integration-guide/v1/web-integration/payment-links.mdx
@@ -129,13 +129,20 @@ Listen for the `PAYMENT_SUCCESSFUL` webhook event to get real-time updates.
     "version": "1.0",
     "sequence_number": "e40552bf-ed12-4f35-9a97-162d97e6fa34",
     "data": {
-        "status": "captured",
-        "message": "Payment successful",
-        "mop_type": "upi",
+        "utr": null,
+        "amount": 1000,
+        "status": "CAPTURED",
+        "message": "Payment Captured",
+        "mop_type": "UPI",
         "order_id": "OD3376378679",
         "payment_id": "PR6938527534",
         "bank_ref_num": "OD3376378679-PR6938527534",
-        "payment_completed_at": "2025-06-24T12:30:44.000000Z"
+        "extended_status": "SUCCESS",
+        "payment_message": null,
+        "subscription_id": null,
+        "virtual_account_id": null,
+        "payment_completed_at": "2025-06-24T12:30:44.000000Z",
+        "merchant_reference_id": "S2SICR1QPJ"
     }
 }
 ```

--- a/integration-guide/v1/web-integration/s2s-card-payment.mdx
+++ b/integration-guide/v1/web-integration/s2s-card-payment.mdx
@@ -393,13 +393,20 @@ EximPe sends real-time webhook notifications when payment status changes:
     "version": "1.0",
     "sequence_number": "e40552bf-ed12-4f35-9a97-162d97e6fa34",
     "data": {
-        "status": "captured",
-        "message": "Payment successful",
-        "mop_type": "debit_card",
+        "utr": null,
+        "amount": 1000,
+        "status": "CAPTURED",
+        "message": "Payment Captured",
+        "mop_type": "DEBIT_CARD",
         "order_id": "OD3376378679",
         "payment_id": "PR6938527534",
         "bank_ref_num": "OD3376378679-PR6938527534",
-        "payment_completed_at": "2025-06-24T12:30:44.000000Z"
+        "extended_status": "SUCCESS",
+        "payment_message": null,
+        "subscription_id": null,
+        "virtual_account_id": null,
+        "payment_completed_at": "2025-06-24T12:30:44.000000Z",
+        "merchant_reference_id": "S2SICR1QPJ"
     }
 }
 ```

--- a/integration-guide/v2/web-integration/payment-links.mdx
+++ b/integration-guide/v2/web-integration/payment-links.mdx
@@ -129,13 +129,20 @@ Listen for the `PAYMENT_SUCCESSFUL` webhook event to get real-time updates.
     "version": "1.0",
     "sequence_number": "e40552bf-ed12-4f35-9a97-162d97e6fa34",
     "data": {
-        "status": "captured",
-        "message": "Payment successful",
-        "mop_type": "upi",
+        "utr": null,
+        "amount": 1000,
+        "status": "CAPTURED",
+        "message": "Payment Captured",
+        "mop_type": "UPI",
         "order_id": "OD3376378679",
         "payment_id": "PR6938527534",
         "bank_ref_num": "OD3376378679-PR6938527534",
-        "payment_completed_at": "2025-06-24T12:30:44.000000Z"
+        "extended_status": "SUCCESS",
+        "payment_message": null,
+        "subscription_id": null,
+        "virtual_account_id": null,
+        "payment_completed_at": "2025-06-24T12:30:44.000000Z",
+        "merchant_reference_id": "S2SICR1QPJ"
     }
 }
 ```

--- a/integration-guide/v2/web-integration/s2s-card-payment.mdx
+++ b/integration-guide/v2/web-integration/s2s-card-payment.mdx
@@ -317,13 +317,20 @@ EximPe sends real-time webhook notifications when payment status changes:
     "version": "1.0",
     "sequence_number": "e40552bf-ed12-4f35-9a97-162d97e6fa34",
     "data": {
-        "status": "captured",
-        "message": "Payment successful",
-        "mop_type": "credit_card",
+        "utr": null,
+        "amount": 1000,
+        "status": "CAPTURED",
+        "message": "Payment Captured",
+        "mop_type": "CREDIT_CARD",
         "order_id": "OD3376378679",
         "payment_id": "PR6938527534",
         "bank_ref_num": "OD3376378679-PR6938527534",
-        "payment_completed_at": "2025-06-24T12:30:44.000000Z"
+        "extended_status": "SUCCESS",
+        "payment_message": null,
+        "subscription_id": null,
+        "virtual_account_id": null,
+        "payment_completed_at": "2025-06-24T12:30:44.000000Z",
+        "merchant_reference_id": "S2SICR1QPJ"
     }
 }
 ```

--- a/integration-guide/v2/web-integration/s2s-netbanking.mdx
+++ b/integration-guide/v2/web-integration/s2s-netbanking.mdx
@@ -182,13 +182,20 @@ EximPe sends real-time webhook notifications when payment status changes:
     "version": "1.0",
     "sequence_number": "e40552bf-ed12-4f35-9a97-162d97e6fa34",
     "data": {
-        "status": "captured",
-        "message": "Payment successful",
-        "mop_type": "net_banking",
+        "utr": null,
+        "amount": 1000,
+        "status": "CAPTURED",
+        "message": "Payment Captured",
+        "mop_type": "NET_BANKING",
         "order_id": "OD9123456789",
         "payment_id": "PR6938527534",
         "bank_ref_num": "OD9123456789-PR6938527534",
-        "payment_completed_at": "2025-06-24T12:30:44.000000Z"
+        "extended_status": "SUCCESS",
+        "payment_message": null,
+        "subscription_id": null,
+        "virtual_account_id": null,
+        "payment_completed_at": "2025-06-24T12:30:44.000000Z",
+        "merchant_reference_id": "S2SICR1QPJ"
     }
 }
 ```

--- a/integration-guide/v2/web-integration/subscription-card.mdx
+++ b/integration-guide/v2/web-integration/subscription-card.mdx
@@ -84,11 +84,13 @@ curl -X POST https://api-pacb.eximpe.com/pg/subscriptions/card/ \
     },
     "mop_type": "credit_card",
     "card_details": {
-        "card_number": "4111111111111111",
-        "card_holder_name": "John Doe",
-        "card_expiry_month": "12",
-        "card_expiry_year": "2027",
-        "card_cvv": "123"
+        "number": "4111111111111111",
+        "cardholder_name": "John Doe",
+        "expiry_month": 12,
+        "expiry_year": 2027,
+        "cvv": "123",
+        "network": "VISA",
+        "nickname": "My Credit Card"
     }
 }'
 ```

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -3188,11 +3188,13 @@
                 },
                 "mop_type": "credit_card",
                 "card_details": {
-                  "card_number": "4111111111111111",
-                  "card_holder_name": "John Doe",
-                  "card_expiry_month": "12",
-                  "card_expiry_year": "2027",
-                  "card_cvv": "123"
+                  "number": "4111111111111111",
+                  "cardholder_name": "John Doe",
+                  "expiry_month": 12,
+                  "expiry_year": 2027,
+                  "cvv": "123",
+                  "network": "VISA",
+                  "nickname": "My Credit Card"
                 }
               }
             }

--- a/openapi/v2-subscriptions.json
+++ b/openapi/v2-subscriptions.json
@@ -323,11 +323,13 @@
                 },
                 "mop_type": "credit_card",
                 "card_details": {
-                  "card_number": "4111111111111111",
-                  "card_holder_name": "John Doe",
-                  "card_expiry_month": "12",
-                  "card_expiry_year": "2027",
-                  "card_cvv": "123"
+                  "number": "4111111111111111",
+                  "cardholder_name": "John Doe",
+                  "expiry_month": 12,
+                  "expiry_year": 2027,
+                  "cvv": "123",
+                  "network": "VISA",
+                  "nickname": "My Credit Card"
                 }
               }
             }
@@ -598,25 +600,33 @@
                 "type": "object",
                 "description": "Card details for card-based subscriptions",
                 "properties": {
-                  "card_number": {
+                  "number": {
                     "type": "string",
-                    "description": "Card number"
+                    "description": "Card number (will be tokenized for security)"
                   },
-                  "card_holder_name": {
+                  "cardholder_name": {
                     "type": "string",
                     "description": "Name on the card"
                   },
-                  "card_expiry_month": {
-                    "type": "string",
+                  "expiry_month": {
+                    "type": "integer",
                     "description": "Card expiry month (MM)"
                   },
-                  "card_expiry_year": {
-                    "type": "string",
+                  "expiry_year": {
+                    "type": "integer",
                     "description": "Card expiry year (YYYY)"
                   },
-                  "card_cvv": {
+                  "cvv": {
                     "type": "string",
                     "description": "Card CVV"
+                  },
+                  "network": {
+                    "type": "string",
+                    "description": "Card network (e.g., VISA, MASTERCARD)"
+                  },
+                  "nickname": {
+                    "type": "string",
+                    "description": "Card nickname for easy identification"
                   }
                 }
               }


### PR DESCRIPTION
## Summary
- Standardized card subscription `card_details` to the `number`/`cardholder_name`/`expiry_month`/`expiry_year`/`cvv`/`network`/`nickname` shape across v1 and v2 integration guides and openapi specs (v1's openapi example and v2-subscriptions.json were stale/out of sync with the rest of the spec).
- Updated `PAYMENT_SUCCESSFUL` and `PAYMENT_FAILED` webhook docs (v1 + v2) to include `amount`, `extended_status`, `payment_message`, `subscription_id`, `virtual_account_id`, `merchant_reference_id`.
- Updated `PAYMENT_REFUNDED` webhook docs (v1 + v2): renamed `payment_request_id`/`amount` to `payment_id`/`refund_amount`, added `comments`, `order_reference_id`, `refund_completed_at`, `refund_reference_id`.
- Updated `REFUND_FAILED` and `REFUND_STATUS_UPDATE` webhook docs (v1 + v2) to add `order_reference_id` and `refund_reference_id` (existing `refund_status` field kept as-is).

## Test plan
- [ ] Validated `openapi/openapi.json` and `openapi/v2-subscriptions.json` parse as valid JSON
- [ ] Spot-check rendered MDX pages for the updated webhook/integration-guide docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)