### PR TITLE
docs(v3): re-add S2S UPI Intent and add the payment verification details flow

### DIFF
--- a/api-reference/v3/order/create.mdx
+++ b/api-reference/v3/order/create.mdx
@@ -5,29 +5,13 @@ openapi: 'POST /pg/orders/'
 
 ## Overview
 
-The Create Order endpoint is the first step in the payment flow across all collection modes. It creates a new order with buyer details, product information, and your preferred payment collection settings (Hosted Payment, Server-to-Server, Payment Link, etc.).
+The Create Order endpoint is the first step in the S2S UPI Intent payment flow. It creates a new order with buyer details, product information, and your payment collection settings.
 
-After creating an order, the response depends on the selected mode:
-- Hosted Payment: returns a `session_id` and `order_id` for redirecting customers to the checkout page
-- S2S UPI Intent: returns an `order_id` and `intent_uri`
-- S2S Card: returns an `order_id` and an `acs_template` (Base64) for 3D Secure
-- S2S Net Banking: returns an `order_id` and an `acs_template` (Base64) for bank redirect
+For the S2S UPI Intent flow, set `collection_mode` to `s2s`, `mop_type` to `upi`, and `upi_flow_type` to `intent`. The response returns an `order_id` and an `intent_uri` that you use to launch the customer's UPI app.
 
-## Payment Collection Modes
-
-EximPe supports multiple payment collection modes:
-
-### 1. Hosted Payment (Default)
-The standard hosted payment flow where customers are redirected to EximPe's secure payment page.
-
-### 2. S2S UPI Intent
-Server-to-server UPI intent flow that generates a UPI intent link for direct app-to-app payments.
-
-### 3. S2S Card Payment
-Server-to-server card payment flow with 3D Secure authentication. For new cards, the system initiates 3D Secure verification and returns an ACS template that must be rendered on the client side to complete authentication. Card details are securely processed and can be tokenized using the [Create Token API](/api-reference/card-tokens/save) after successful payment.
-
-### 4. S2S Net Banking
-Server-to-server net banking flow. EximPe returns an ACS template (Base64-encoded HTML) that you render in the customer's browser, automatically redirecting them to their bank's net banking portal to authorise the payment.
+<Note>
+  See the [S2S UPI Intent integration guide](/integration-guide/v3/web-integration/s2s-upi-intent) for the end-to-end flow, including how to invoke the intent URI on Android, iOS, and desktop.
+</Note>
 
 ## Request Parameters
 
@@ -40,35 +24,20 @@ Server-to-server net banking flow. EximPe returns an ACS template (Base64-encode
 - `product`: Product details object
 - `invoice`: Invoice details object
 
-### Optional Parameters
-- `collection_mode`: Payment collection mode (`hosted_payment` or `s2s`)
-- `mop_type`: Method of payment (`upi`, `credit_card`, `debit_card`, `net_banking`, `qr`)
-- `upi_flow_type`: UPI flow type (`intent`) - required when using S2S with UPI
-- `card_details`: Card information object - required when `mop_type` is `credit_card` or `debit_card`
-- `netbanking_details`: Net banking details object - required when `mop_type` is `net_banking`
+### S2S UPI Intent Parameters
+- `collection_mode`: Must be `s2s`
+- `mop_type`: Must be `upi`
+- `upi_flow_type`: Must be `intent`
+- `buyer.ip_address`: Customer's IP address
+- `buyer.user_agent`: Customer's browser user agent
 
-### Card Payment Specific Parameters
-When using card payments (`mop_type` is `credit_card` or `debit_card`), additional buyer information is required:
-- `buyer.ip_address`: Customer's IP address (used for fraud prevention)
-- `buyer.user_agent`: Customer's browser user agent (used for fraud prevention)
-
-#### Card Details Options
-You can provide card information in two ways:
-
-1. **New Card Details** (for first-time payments):
-   - Include full card information: `number`, `cardholder_name`, `expiry_month`, `expiry_year`, `cvv`, `network`
-   - Required for new cards not previously saved
-   - Use the [Create Token API](/api-reference/card-tokens/save) after successful payment to tokenize for future use
-
-2. **Saved Card Token** (for repeat payments):
-   - Use `token`: Previously saved card token from the [Create Token API](/api-reference/card-tokens/save)
-   - Include `identifier`: Customer identifier used when saving the card
-   - Include `network`: Card network (visa, mastercard, etc.)
-   - No sensitive card data required - token handles authentication
+<Note>
+  `buyer.ip_address` and `buyer.user_agent` are required for the S2S UPI Intent flow in addition to the standard checkout fields.
+</Note>
 
 ### Parameter Definitions
 
-The following tables define all request parameters, including nested objects, types, requirements, and constraints.
+The following tables define the request parameters used by the S2S UPI Intent flow, including nested objects, types, requirements, and constraints.
 
 #### Top-level
 
@@ -77,18 +46,13 @@ The following tables define all request parameters, including nested objects, ty
 | amount | string | Yes | Amount to charge, decimal string. | Format: `^[0-9]+(\.[0-9]{1,2})?$`; amount must be > 0 and ≤ 10,000,000.00 |
 | currency | string | Yes | 3-letter ISO currency code. | Supported: `INR` |
 | reference_id | string | Yes | Merchant-side unique reference for the order. | 1–50 chars; use letters, numbers, and dashes; unique per merchant while order is active |
-| collection_mode | string | No | Mode of payment collection. | Enum: `hosted_payment`, `s2s`; default `hosted_payment` |
-| mop_type | string | No | Method of payment. | Enum: `upi`, `credit_card`, `debit_card`, `net_banking`, `wallet`, `qr` |
-| upi_flow_type | string | Conditionally | UPI flow when `mop_type` is `UPI` and `collection_mode` is `s2s`. | Required if `mop_type=UPI` and `collection_mode=s2s`; Enum: `intent`, `collection` |
+| collection_mode | string | Yes | Mode of payment collection. | Must be `s2s` for this flow |
+| mop_type | string | Yes | Method of payment. | Must be `upi` for this flow |
+| upi_flow_type | string | Yes | UPI flow when `mop_type` is `upi` and `collection_mode` is `s2s`. | Must be `intent` for this flow |
 | return_url | string | Yes | URL to redirect after payment/auth completion. | HTTPS URL recommended |
 | buyer | object | Yes | Buyer/customer details. | See Buyer object |
 | product | object | Yes | Product or service being purchased. | See Product object |
 | invoice | object | Yes | Invoice metadata. | See Invoice object |
-| card_details | object | Conditionally | Card details or token for card payments. | Required if `mop_type` is `credit_card` or `debit_card`; See Card Details |
-| netbanking_details | object | Conditionally | Net banking details. | Required if `mop_type` is `net_banking`; See Net Banking Details |
-
-Notes:
-- "Conditionally" required means the field is required only when the stated condition is met.
 
 #### Buyer
 
@@ -98,8 +62,8 @@ Notes:
 | email | string | Yes | Email of the buyer. | RFC 5322 email format |
 | phone | string | Yes | Phone number with country code. | Valid phone number; E.164 preferred (e.g., `+9198xxxxxxxx`) |
 | address | object | Yes | Buyer address. | See Address object |
-| ip_address | string | Optional | Customer IP address for card fraud checks. | IPv4/IPv6 |
-| user_agent | string | Optional | Browser/device user agent for card fraud checks. | typical browser user agent string |
+| ip_address | string | Yes | Customer IP address. | IPv4/IPv6 |
+| user_agent | string | Yes | Browser/device user agent. | Typical browser user agent string |
 
 #### Address (Buyer.address)
 
@@ -128,100 +92,23 @@ Notes:
 | number | string | Yes | Invoice number. | Max 255 chars; letters, numbers, dashes/slashes |
 | date | string | No | Invoice date (ISO 8601). | Format: `YYYY-MM-DD` |
 
-#### Card Details
-
-Provide one of the following variants when `mop_type` is `credit_card` or `debit_card`:
-
-- New card (full PAN):
-  - `number` (string, required): PAN; numeric 12-19 digits
-  - `cardholder_name` (string, required): Name on card; max 128 chars
-  - `expiry_month` (string, required): `MM` format; `01`-`12`
-  - `expiry_year` (string, required): `YYYY`; current year or later
-  - `cvv` (string, required): 3-4 digits
-  - `network` (string, required): Enum: `visa`, `mastercard`, `rupay`, `amex`, `diners`, `discover`
-  - `nickname` (string, required): Friendly label; max 64 chars
-  - `identifier` (string, required): Customer identifier used for future reference
-
-- Saved card (tokenized):
-  - `token` (string, required): Token from Create Token API
-  - `identifier` (string, required): Customer identifier used when saving the card
-  - `network` (string, required): Card network; same enum as above
-
-Security:
-- Do not log or store raw PAN/CVV. Use HTTPS and comply with applicable PCI requirements.
-
-#### Net Banking Details
-
-Provide the following when `mop_type` is `net_banking`:
-
-| Name | Type | Required | Description | Constraints |
-|---|---|---|---|---|
-| bank_name | string | Yes | Name of the customer's bank. | Must be one of the supported bank names — see [Supported Banks](/integration-guide/v2/web-integration/s2s-netbanking#supported-banks) |
-
 ## Response
 
-### Hosted Payment Response
-For hosted payment mode, the response includes:
-- `session_id`: Use this to redirect customers to the payment page
-- `order_id`: Unique order identifier
-
-### S2S UPI Intent Response
 For S2S UPI Intent mode, the response includes:
 - `order_id`: Unique order identifier
 - `intent_uri`: UPI intent link that can be used to open UPI apps directly
 
-### S2S Card Payment Response
-For S2S Card Payment mode, the response includes:
-- `order_id`: Unique order identifier
-- `acs_template`: Base64-encoded HTML template for 3D Secure authentication
-
-**Important**: The `acs_template` must be decoded from Base64 and rendered in the customer's browser to complete the 3D Secure authentication process.
-
-### S2S Net Banking Response
-For S2S Net Banking mode, the response includes:
-- `order_id`: Unique order identifier
-- `acs_template`: Base64-encoded HTML form that redirects the customer to their bank's net banking portal
-
-**Important**: Decode the `acs_template` from Base64 and render it in the customer's browser. The embedded form auto-submits to the bank's portal.
-
 ## Examples
-
-<CodeGroup>
-
-```json Hosted Payment
-{
-  "amount": "1000.00",
-  "currency": "INR", 
-  "reference_id": "ORDER_123456",
-  "collection_mode": "hosted_payment",
-  "return_url": "https://yourdomain.com/payment/callback",
-  "mop_type": "upi",
-  "buyer": {
-    "name": "Alice Smith",
-    "email": "alice.smith@example.com",
-    "phone": "+919812345678",
-    "address": {
-      "line_1": "221B Baker Street",
-      "city": "Mumbai",
-      "state": "Maharashtra", 
-      "postal_code": "400001"
-    }
-  },
-  "product": {
-    "name": "Wireless Headphones",
-    "type_of_goods": "physical_goods"
-  }
-}
-```
 
 ```json S2S UPI Intent
 {
   "amount": "1000.00",
   "currency": "INR",
-  "reference_id": "ORDER_123457", 
+  "reference_id": "ORDER_123457",
   "collection_mode": "s2s",
   "mop_type": "upi",
   "upi_flow_type": "intent",
+  "return_url": "https://yourdomain.com/payment/callback/",
   "buyer": {
     "name": "John Doe",
     "email": "john.doe@example.com",
@@ -231,49 +118,12 @@ For S2S Net Banking mode, the response includes:
       "city": "Delhi",
       "state": "Delhi",
       "postal_code": "110001"
-    }
-  },
-  "product": {
-    "name": "Smartphone", 
-    "type_of_goods": "physical_goods"
-  }
-}
-```
-
-```json S2S Card Payment
-{
-  "amount": "1000.00",
-  "currency": "INR",
-  "reference_id": "CARD_13MYHALESH7",
-  "return_url": "https://yourdomain.com/checkout/callback/",
-  "collection_mode": "s2s",
-  "mop_type": "debit_card",
-  "card_details": {
-    "nickname": "My Card",
-    "number": "4895380110000003",
-    "cardholder_name": "John Doe",
-    "expiry_month": "05",
-    "expiry_year": "2030",
-    "cvv": "123",
-    "network": "visa",
-    "identifier": "EX0001"
-  },
-  "buyer": {
-    "name": "John Doe",
-    "email": "john.doe@example.com",
-    "phone": "+919876543210",
-    "address": {
-      "line_1": "123 Main Street",
-      "line_2": "Apt 4B",
-      "city": "City",
-      "state": "State",
-      "postal_code": "123456"
     },
     "ip_address": "192.168.1.100",
-    "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
+    "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"
   },
   "product": {
-    "name": "Sample Product",
+    "name": "Smartphone",
     "description": "This is a sample product description",
     "hs_code": "98051000",
     "hs_code_description": "Portable automatic data processing machines",
@@ -286,102 +136,7 @@ For S2S Net Banking mode, the response includes:
 }
 ```
 
-```json S2S Card Payment (Saved Token)
-{
-  "amount": "1000.00",
-  "currency": "INR",
-  "reference_id": "CARD_4FQ0AIHQEI9",
-  "return_url": "https://yourdomain.com/checkout/callback/",
-  "collection_mode": "s2s",
-  "mop_type": "credit_card",
-  "card_details": {
-    "token": "1e6709282a21e83f43a020",
-    "identifier": "EX0001",
-    "network": "visa"
-  },
-  "buyer": {
-    "name": "John Doe",
-    "email": "john.doe@example.com",
-    "phone": "+919876543210",
-    "address": {
-      "line_1": "123 Main Street",
-      "line_2": "Apt 4B",
-      "city": "City",
-      "state": "State",
-      "postal_code": "123456"
-    },
-    "ip_address": "192.168.1.100",
-    "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
-  },
-  "product": {
-    "name": "Sample Product",
-    "description": "This is a sample product description",
-    "hs_code": "98051000",
-    "hs_code_description": "Portable automatic data processing machines",
-    "type_of_goods": "physical_goods"
-  },
-  "invoice": {
-    "number": "INV_3MUK2I",
-    "date": "2025-09-04"
-  }
-}
-```
-
-```json S2S Net Banking
-{
-  "amount": "1000.00",
-  "currency": "INR",
-  "reference_id": "S2SNB_REF123",
-  "return_url": "https://yourdomain.com/payment/callback/",
-  "collection_mode": "s2s",
-  "mop_type": "net_banking",
-  "netbanking_details": {
-    "bank_name": "Axis Bank"
-  },
-  "buyer": {
-    "name": "John Doe",
-    "email": "john.doe@example.com",
-    "phone": "+919876543210",
-    "address": {
-      "line_1": "123 Main Street",
-      "line_2": "Apt 4B",
-      "city": "Mumbai",
-      "state": "Maharashtra",
-      "postal_code": "400001"
-    },
-    "ip_address": "192.168.1.100",
-    "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"
-  },
-  "product": {
-    "name": "Sample Product",
-    "description": "This is a sample product description",
-    "hs_code": "98051000",
-    "hs_code_description": "Portable automatic data processing machines",
-    "type_of_goods": "physical_goods"
-  },
-  "invoice": {
-    "number": "INV_NB001",
-    "date": "2025-09-04"
-  }
-}
-```
-
-</CodeGroup>
-
 ## Response Examples
-
-<CodeGroup>
-
-```json Hosted Payment Response
-{
-  "success": true,
-  "message": "Checkout session created successfully",
-  "data": {
-    "session_id": "session_abc123def456",
-    "order_id": "OD2000992103"
-  }
-}
-```
 
 ```json S2S UPI Intent Response
 {
@@ -394,57 +149,8 @@ For S2S Net Banking mode, the response includes:
 }
 ```
 
-```json S2S Card Payment Response
-{
-  "success": true,
-  "message": "S2S Card Payment Request created successfully",
-  "data": {
-    "order_id": "OD9888127185",
-    "acs_template": "PGh0bWw+PGJvZHk+PGZvcm0gbmFtZT0icGF5bWVudF9wb3N0IiBpZD0icGF5bWVudF9wb3N0IiBhY3Rpb249Imh0dHBzOi8vdGVzdC5wYXl1LmluL2UxMGMzNmExYWQ2YTQ1OTkzMWNhODYzNTBhZjIxZDU0ZDhiMTZhODRjYWQ1NDAxMDE2OGFlN2RjYmEwMmEwYWEvdGhyZWVEU2VjdXJlL21ldGhvZCIgbWV0aG9kPSJwb3N0Ij4uLi4="
-  }
-}
-```
-
-```json S2S Net Banking Response
-{
-  "success": true,
-  "message": "S2S Net Banking Payment Request created successfully",
-  "data": {
-    "order_id": "OD9123456789",
-    "acs_template": "PGh0bWw+PGJvZHk+PGZvcm0gbmFtZT0icGF5bWVudF9wb3N0..."
-  }
-}
-```
-
-</CodeGroup>
-
 ## Implementation Notes
 
-### UPI Payments
-- **S2S UPI Intent**: The response includes a UPI intent link that can be used to open UPI apps directly
-
-### Card Payments
-- **3D Secure Flow**: For new cards, the system initiates 3D Secure verification
-- **ACS Template Processing**: 
-  1. Decode the Base64 `acs_template` from the response
-  2. Render the decoded HTML in the customer's browser
-  3. The form will auto-submit to complete 3D Secure authentication
-  4. Customer will be redirected back to your `return_url` after authentication
-- **Card Tokenization**: Use the [Create Token API](/api-reference/card-tokens/save) after successful payment to securely tokenize cards for future use
-- **Saved Card Usage**: Use previously saved card tokens for faster, more secure repeat payments
-- **Fraud Prevention**: `ip_address` and `user_agent` are required for fraud detection and prevention
-
-#### New vs Saved Cards
-- **New Cards**: Require full card details and may trigger 3D Secure authentication
-- **Saved Cards**: Use tokens for faster processing, reduced 3D Secure requirements, and enhanced security
-- **Token Benefits**: No sensitive data exposure, faster checkout, improved conversion rates
-
-### Net Banking Payments
-- **ACS Template**: Decode the Base64 `acs_template` and render it in the customer's browser — the embedded form auto-submits to the bank's portal
-- **Required Fields**: `buyer.ip_address` and `buyer.user_agent` are required for fraud prevention
-- **Supported Banks**: See the [full list of supported banks](/integration-guide/v2/web-integration/s2s-netbanking#supported-banks)
-
-### Security Considerations
-- **Card Data**: Never log or store card details in your application
-- **3D Secure**: Always implement proper 3D Secure handling for card payments
-- **Token Management**: Use the [Card Token APIs](/api-reference/card-tokens/save) for managing saved cards
+- The response includes a UPI intent link (`intent_uri`) that can be used to open UPI apps directly. Prefix it with `upi://pay?` (or an app-specific scheme) before invoking it — see the [integration guide](/integration-guide/v3/web-integration/s2s-upi-intent#step-3-invoke-upi-intent) for platform-specific handling.
+- Poll the [Order Status API](/api-reference/v3/order/get-status) or wait for the [Payment Successful webhook](/api-reference/v3/webhooks/payment-successful) to confirm the outcome.
+- `buyer.ip_address` and `buyer.user_agent` are required for fraud prevention.

--- a/api-reference/v3/order/create.mdx
+++ b/api-reference/v3/order/create.mdx
@@ -97,6 +97,11 @@ The following tables define the request parameters used by the S2S UPI Intent fl
 For S2S UPI Intent mode, the response includes:
 - `order_id`: Unique order identifier
 - `intent_uri`: UPI intent link that can be used to open UPI apps directly
+- `test_simulator_url`: **Sandbox only** — a URL you open in a browser to complete the payment without a real UPI app
+
+<Tip>
+  In the **sandbox environment**, the response carries an extra `test_simulator_url`. Open it in a browser to simulate the payment flow and complete the transaction without a real UPI app or a mobile device. The result follows the test VPA you use in the simulator. This field is **not returned in production**.
+</Tip>
 
 ## Examples
 
@@ -138,6 +143,8 @@ For S2S UPI Intent mode, the response includes:
 
 ## Response Examples
 
+<CodeGroup>
+
 ```json S2S UPI Intent Response
 {
   "success": true,
@@ -148,6 +155,20 @@ For S2S UPI Intent mode, the response includes:
   }
 }
 ```
+
+```json S2S UPI Intent Response (Sandbox)
+{
+  "success": true,
+  "message": "S2S UPI Request created successfully",
+  "data": {
+    "intent_uri": "pa=kk.payutest@hdfcbank&pn=&tr=403993715534292371&tid=PPPL403993715534292371080725205418&am=1000.00&cu=INR&tn=UPIIntent",
+    "order_id": "OD2000992103",
+    "test_simulator_url": "<simulator URL returned by the sandbox API>"
+  }
+}
+```
+
+</CodeGroup>
 
 ## Implementation Notes
 

--- a/api-reference/v3/order/create.mdx
+++ b/api-reference/v3/order/create.mdx
@@ -1,0 +1,450 @@
+---
+title: 'Create Order'
+openapi: 'POST /pg/orders/'
+---
+
+## Overview
+
+The Create Order endpoint is the first step in the payment flow across all collection modes. It creates a new order with buyer details, product information, and your preferred payment collection settings (Hosted Payment, Server-to-Server, Payment Link, etc.).
+
+After creating an order, the response depends on the selected mode:
+- Hosted Payment: returns a `session_id` and `order_id` for redirecting customers to the checkout page
+- S2S UPI Intent: returns an `order_id` and `intent_uri`
+- S2S Card: returns an `order_id` and an `acs_template` (Base64) for 3D Secure
+- S2S Net Banking: returns an `order_id` and an `acs_template` (Base64) for bank redirect
+
+## Payment Collection Modes
+
+EximPe supports multiple payment collection modes:
+
+### 1. Hosted Payment (Default)
+The standard hosted payment flow where customers are redirected to EximPe's secure payment page.
+
+### 2. S2S UPI Intent
+Server-to-server UPI intent flow that generates a UPI intent link for direct app-to-app payments.
+
+### 3. S2S Card Payment
+Server-to-server card payment flow with 3D Secure authentication. For new cards, the system initiates 3D Secure verification and returns an ACS template that must be rendered on the client side to complete authentication. Card details are securely processed and can be tokenized using the [Create Token API](/api-reference/card-tokens/save) after successful payment.
+
+### 4. S2S Net Banking
+Server-to-server net banking flow. EximPe returns an ACS template (Base64-encoded HTML) that you render in the customer's browser, automatically redirecting them to their bank's net banking portal to authorise the payment.
+
+## Request Parameters
+
+### Required Parameters
+- `reference_id`: Unique identifier for the order
+- `amount`: Payment amount in decimal format
+- `currency`: 3-letter ISO currency code (e.g., INR)
+- `return_url`: URL to redirect after payment completion
+- `buyer`: Buyer details object
+- `product`: Product details object
+- `invoice`: Invoice details object
+
+### Optional Parameters
+- `collection_mode`: Payment collection mode (`hosted_payment` or `s2s`)
+- `mop_type`: Method of payment (`upi`, `credit_card`, `debit_card`, `net_banking`, `qr`)
+- `upi_flow_type`: UPI flow type (`intent`) - required when using S2S with UPI
+- `card_details`: Card information object - required when `mop_type` is `credit_card` or `debit_card`
+- `netbanking_details`: Net banking details object - required when `mop_type` is `net_banking`
+
+### Card Payment Specific Parameters
+When using card payments (`mop_type` is `credit_card` or `debit_card`), additional buyer information is required:
+- `buyer.ip_address`: Customer's IP address (used for fraud prevention)
+- `buyer.user_agent`: Customer's browser user agent (used for fraud prevention)
+
+#### Card Details Options
+You can provide card information in two ways:
+
+1. **New Card Details** (for first-time payments):
+   - Include full card information: `number`, `cardholder_name`, `expiry_month`, `expiry_year`, `cvv`, `network`
+   - Required for new cards not previously saved
+   - Use the [Create Token API](/api-reference/card-tokens/save) after successful payment to tokenize for future use
+
+2. **Saved Card Token** (for repeat payments):
+   - Use `token`: Previously saved card token from the [Create Token API](/api-reference/card-tokens/save)
+   - Include `identifier`: Customer identifier used when saving the card
+   - Include `network`: Card network (visa, mastercard, etc.)
+   - No sensitive card data required - token handles authentication
+
+### Parameter Definitions
+
+The following tables define all request parameters, including nested objects, types, requirements, and constraints.
+
+#### Top-level
+
+| Name | Type | Required | Description | Constraints |
+|---|---|---|---|---|
+| amount | string | Yes | Amount to charge, decimal string. | Format: `^[0-9]+(\.[0-9]{1,2})?$`; amount must be > 0 and ≤ 10,000,000.00 |
+| currency | string | Yes | 3-letter ISO currency code. | Supported: `INR` |
+| reference_id | string | Yes | Merchant-side unique reference for the order. | 1–50 chars; use letters, numbers, and dashes; unique per merchant while order is active |
+| collection_mode | string | No | Mode of payment collection. | Enum: `hosted_payment`, `s2s`; default `hosted_payment` |
+| mop_type | string | No | Method of payment. | Enum: `upi`, `credit_card`, `debit_card`, `net_banking`, `wallet`, `qr` |
+| upi_flow_type | string | Conditionally | UPI flow when `mop_type` is `UPI` and `collection_mode` is `s2s`. | Required if `mop_type=UPI` and `collection_mode=s2s`; Enum: `intent`, `collection` |
+| return_url | string | Yes | URL to redirect after payment/auth completion. | HTTPS URL recommended |
+| buyer | object | Yes | Buyer/customer details. | See Buyer object |
+| product | object | Yes | Product or service being purchased. | See Product object |
+| invoice | object | Yes | Invoice metadata. | See Invoice object |
+| card_details | object | Conditionally | Card details or token for card payments. | Required if `mop_type` is `credit_card` or `debit_card`; See Card Details |
+| netbanking_details | object | Conditionally | Net banking details. | Required if `mop_type` is `net_banking`; See Net Banking Details |
+
+Notes:
+- "Conditionally" required means the field is required only when the stated condition is met.
+
+#### Buyer
+
+| Name | Type | Required | Description | Constraints |
+|---|---|---|---|---|
+| name | string | Yes | Full name of the buyer. | Max 255 chars; letters, spaces, and common name punctuation (.,-' ) |
+| email | string | Yes | Email of the buyer. | RFC 5322 email format |
+| phone | string | Yes | Phone number with country code. | Valid phone number; E.164 preferred (e.g., `+9198xxxxxxxx`) |
+| address | object | Yes | Buyer address. | See Address object |
+| ip_address | string | Optional | Customer IP address for card fraud checks. | IPv4/IPv6 |
+| user_agent | string | Optional | Browser/device user agent for card fraud checks. | typical browser user agent string |
+
+#### Address (Buyer.address)
+
+| Name | Type | Required | Description | Constraints |
+|---|---|---|---|---|
+| line_1 | string | No | Address line 1. | Text up to ~255 chars; use standard address characters (letters, numbers, spaces, , . - / #) |
+| line_2 | string | No | Address line 2. | Text up to ~255 chars; use standard address characters (letters, numbers, spaces, , . - / #) |
+| city | string | No | City. | Alphabetic only; Max 255 chars |
+| state | string | No | State/Province. | Alphabetic only; Max 255 chars |
+| postal_code | string | Yes | Postal/ZIP code. | 6 chars; numbers |
+
+#### Product
+
+| Name | Type | Required | Description | Constraints |
+|---|---|---|---|---|
+| name | string | Yes | Product or service name. | Max 255 chars; letters, numbers, spaces, and common punctuation |
+| description | string | No | Description of the product/service. | Max 1024 chars; letters, numbers, spaces, and common punctuation |
+| type_of_goods | string | Yes | Nature of goods/services. | Enum: `digital_goods`, `physical_goods`, `service` |
+| hs_code | string | Conditional | 8-digit HS Code. Required for physical goods | Max 8 chars; numbers |
+| hs_code_description | string | No | HS Code description. | Max 1024 chars; letters, numbers, spaces, and common punctuation |
+
+#### Invoice
+
+| Name | Type | Required | Description | Constraints |
+|---|---|---|---|---|
+| number | string | Yes | Invoice number. | Max 255 chars; letters, numbers, dashes/slashes |
+| date | string | No | Invoice date (ISO 8601). | Format: `YYYY-MM-DD` |
+
+#### Card Details
+
+Provide one of the following variants when `mop_type` is `credit_card` or `debit_card`:
+
+- New card (full PAN):
+  - `number` (string, required): PAN; numeric 12-19 digits
+  - `cardholder_name` (string, required): Name on card; max 128 chars
+  - `expiry_month` (string, required): `MM` format; `01`-`12`
+  - `expiry_year` (string, required): `YYYY`; current year or later
+  - `cvv` (string, required): 3-4 digits
+  - `network` (string, required): Enum: `visa`, `mastercard`, `rupay`, `amex`, `diners`, `discover`
+  - `nickname` (string, required): Friendly label; max 64 chars
+  - `identifier` (string, required): Customer identifier used for future reference
+
+- Saved card (tokenized):
+  - `token` (string, required): Token from Create Token API
+  - `identifier` (string, required): Customer identifier used when saving the card
+  - `network` (string, required): Card network; same enum as above
+
+Security:
+- Do not log or store raw PAN/CVV. Use HTTPS and comply with applicable PCI requirements.
+
+#### Net Banking Details
+
+Provide the following when `mop_type` is `net_banking`:
+
+| Name | Type | Required | Description | Constraints |
+|---|---|---|---|---|
+| bank_name | string | Yes | Name of the customer's bank. | Must be one of the supported bank names — see [Supported Banks](/integration-guide/v2/web-integration/s2s-netbanking#supported-banks) |
+
+## Response
+
+### Hosted Payment Response
+For hosted payment mode, the response includes:
+- `session_id`: Use this to redirect customers to the payment page
+- `order_id`: Unique order identifier
+
+### S2S UPI Intent Response
+For S2S UPI Intent mode, the response includes:
+- `order_id`: Unique order identifier
+- `intent_uri`: UPI intent link that can be used to open UPI apps directly
+
+### S2S Card Payment Response
+For S2S Card Payment mode, the response includes:
+- `order_id`: Unique order identifier
+- `acs_template`: Base64-encoded HTML template for 3D Secure authentication
+
+**Important**: The `acs_template` must be decoded from Base64 and rendered in the customer's browser to complete the 3D Secure authentication process.
+
+### S2S Net Banking Response
+For S2S Net Banking mode, the response includes:
+- `order_id`: Unique order identifier
+- `acs_template`: Base64-encoded HTML form that redirects the customer to their bank's net banking portal
+
+**Important**: Decode the `acs_template` from Base64 and render it in the customer's browser. The embedded form auto-submits to the bank's portal.
+
+## Examples
+
+<CodeGroup>
+
+```json Hosted Payment
+{
+  "amount": "1000.00",
+  "currency": "INR", 
+  "reference_id": "ORDER_123456",
+  "collection_mode": "hosted_payment",
+  "return_url": "https://yourdomain.com/payment/callback",
+  "mop_type": "upi",
+  "buyer": {
+    "name": "Alice Smith",
+    "email": "alice.smith@example.com",
+    "phone": "+919812345678",
+    "address": {
+      "line_1": "221B Baker Street",
+      "city": "Mumbai",
+      "state": "Maharashtra", 
+      "postal_code": "400001"
+    }
+  },
+  "product": {
+    "name": "Wireless Headphones",
+    "type_of_goods": "physical_goods"
+  }
+}
+```
+
+```json S2S UPI Intent
+{
+  "amount": "1000.00",
+  "currency": "INR",
+  "reference_id": "ORDER_123457", 
+  "collection_mode": "s2s",
+  "mop_type": "upi",
+  "upi_flow_type": "intent",
+  "buyer": {
+    "name": "John Doe",
+    "email": "john.doe@example.com",
+    "phone": "+919876543210",
+    "address": {
+      "line_1": "123 Main Street",
+      "city": "Delhi",
+      "state": "Delhi",
+      "postal_code": "110001"
+    }
+  },
+  "product": {
+    "name": "Smartphone", 
+    "type_of_goods": "physical_goods"
+  }
+}
+```
+
+```json S2S Card Payment
+{
+  "amount": "1000.00",
+  "currency": "INR",
+  "reference_id": "CARD_13MYHALESH7",
+  "return_url": "https://yourdomain.com/checkout/callback/",
+  "collection_mode": "s2s",
+  "mop_type": "debit_card",
+  "card_details": {
+    "nickname": "My Card",
+    "number": "4895380110000003",
+    "cardholder_name": "John Doe",
+    "expiry_month": "05",
+    "expiry_year": "2030",
+    "cvv": "123",
+    "network": "visa",
+    "identifier": "EX0001"
+  },
+  "buyer": {
+    "name": "John Doe",
+    "email": "john.doe@example.com",
+    "phone": "+919876543210",
+    "address": {
+      "line_1": "123 Main Street",
+      "line_2": "Apt 4B",
+      "city": "City",
+      "state": "State",
+      "postal_code": "123456"
+    },
+    "ip_address": "192.168.1.100",
+    "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
+  },
+  "product": {
+    "name": "Sample Product",
+    "description": "This is a sample product description",
+    "hs_code": "98051000",
+    "hs_code_description": "Portable automatic data processing machines",
+    "type_of_goods": "physical_goods"
+  },
+  "invoice": {
+    "number": "INV_0HOZ0C",
+    "date": "2025-09-04"
+  }
+}
+```
+
+```json S2S Card Payment (Saved Token)
+{
+  "amount": "1000.00",
+  "currency": "INR",
+  "reference_id": "CARD_4FQ0AIHQEI9",
+  "return_url": "https://yourdomain.com/checkout/callback/",
+  "collection_mode": "s2s",
+  "mop_type": "credit_card",
+  "card_details": {
+    "token": "1e6709282a21e83f43a020",
+    "identifier": "EX0001",
+    "network": "visa"
+  },
+  "buyer": {
+    "name": "John Doe",
+    "email": "john.doe@example.com",
+    "phone": "+919876543210",
+    "address": {
+      "line_1": "123 Main Street",
+      "line_2": "Apt 4B",
+      "city": "City",
+      "state": "State",
+      "postal_code": "123456"
+    },
+    "ip_address": "192.168.1.100",
+    "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
+  },
+  "product": {
+    "name": "Sample Product",
+    "description": "This is a sample product description",
+    "hs_code": "98051000",
+    "hs_code_description": "Portable automatic data processing machines",
+    "type_of_goods": "physical_goods"
+  },
+  "invoice": {
+    "number": "INV_3MUK2I",
+    "date": "2025-09-04"
+  }
+}
+```
+
+```json S2S Net Banking
+{
+  "amount": "1000.00",
+  "currency": "INR",
+  "reference_id": "S2SNB_REF123",
+  "return_url": "https://yourdomain.com/payment/callback/",
+  "collection_mode": "s2s",
+  "mop_type": "net_banking",
+  "netbanking_details": {
+    "bank_name": "Axis Bank"
+  },
+  "buyer": {
+    "name": "John Doe",
+    "email": "john.doe@example.com",
+    "phone": "+919876543210",
+    "address": {
+      "line_1": "123 Main Street",
+      "line_2": "Apt 4B",
+      "city": "Mumbai",
+      "state": "Maharashtra",
+      "postal_code": "400001"
+    },
+    "ip_address": "192.168.1.100",
+    "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"
+  },
+  "product": {
+    "name": "Sample Product",
+    "description": "This is a sample product description",
+    "hs_code": "98051000",
+    "hs_code_description": "Portable automatic data processing machines",
+    "type_of_goods": "physical_goods"
+  },
+  "invoice": {
+    "number": "INV_NB001",
+    "date": "2025-09-04"
+  }
+}
+```
+
+</CodeGroup>
+
+## Response Examples
+
+<CodeGroup>
+
+```json Hosted Payment Response
+{
+  "success": true,
+  "message": "Checkout session created successfully",
+  "data": {
+    "session_id": "session_abc123def456",
+    "order_id": "OD2000992103"
+  }
+}
+```
+
+```json S2S UPI Intent Response
+{
+  "success": true,
+  "message": "S2S UPI Request created successfully",
+  "data": {
+    "intent_uri": "pa=kk.payutest@hdfcbank&pn=&tr=403993715534292371&tid=PPPL403993715534292371080725205418&am=1000.00&cu=INR&tn=UPIIntent",
+    "order_id": "OD2000992103"
+  }
+}
+```
+
+```json S2S Card Payment Response
+{
+  "success": true,
+  "message": "S2S Card Payment Request created successfully",
+  "data": {
+    "order_id": "OD9888127185",
+    "acs_template": "PGh0bWw+PGJvZHk+PGZvcm0gbmFtZT0icGF5bWVudF9wb3N0IiBpZD0icGF5bWVudF9wb3N0IiBhY3Rpb249Imh0dHBzOi8vdGVzdC5wYXl1LmluL2UxMGMzNmExYWQ2YTQ1OTkzMWNhODYzNTBhZjIxZDU0ZDhiMTZhODRjYWQ1NDAxMDE2OGFlN2RjYmEwMmEwYWEvdGhyZWVEU2VjdXJlL21ldGhvZCIgbWV0aG9kPSJwb3N0Ij4uLi4="
+  }
+}
+```
+
+```json S2S Net Banking Response
+{
+  "success": true,
+  "message": "S2S Net Banking Payment Request created successfully",
+  "data": {
+    "order_id": "OD9123456789",
+    "acs_template": "PGh0bWw+PGJvZHk+PGZvcm0gbmFtZT0icGF5bWVudF9wb3N0..."
+  }
+}
+```
+
+</CodeGroup>
+
+## Implementation Notes
+
+### UPI Payments
+- **S2S UPI Intent**: The response includes a UPI intent link that can be used to open UPI apps directly
+
+### Card Payments
+- **3D Secure Flow**: For new cards, the system initiates 3D Secure verification
+- **ACS Template Processing**: 
+  1. Decode the Base64 `acs_template` from the response
+  2. Render the decoded HTML in the customer's browser
+  3. The form will auto-submit to complete 3D Secure authentication
+  4. Customer will be redirected back to your `return_url` after authentication
+- **Card Tokenization**: Use the [Create Token API](/api-reference/card-tokens/save) after successful payment to securely tokenize cards for future use
+- **Saved Card Usage**: Use previously saved card tokens for faster, more secure repeat payments
+- **Fraud Prevention**: `ip_address` and `user_agent` are required for fraud detection and prevention
+
+#### New vs Saved Cards
+- **New Cards**: Require full card details and may trigger 3D Secure authentication
+- **Saved Cards**: Use tokens for faster processing, reduced 3D Secure requirements, and enhanced security
+- **Token Benefits**: No sensitive data exposure, faster checkout, improved conversion rates
+
+### Net Banking Payments
+- **ACS Template**: Decode the Base64 `acs_template` and render it in the customer's browser — the embedded form auto-submits to the bank's portal
+- **Required Fields**: `buyer.ip_address` and `buyer.user_agent` are required for fraud prevention
+- **Supported Banks**: See the [full list of supported banks](/integration-guide/v2/web-integration/s2s-netbanking#supported-banks)
+
+### Security Considerations
+- **Card Data**: Never log or store card details in your application
+- **3D Secure**: Always implement proper 3D Secure handling for card payments
+- **Token Management**: Use the [Card Token APIs](/api-reference/card-tokens/save) for managing saved cards

--- a/api-reference/v3/order/get-status.mdx
+++ b/api-reference/v3/order/get-status.mdx
@@ -1,0 +1,11 @@
+---
+title: 'Get Order Status'
+description: 'Retrieve current status of an order by order ID.'
+openapi: 'GET /pg/orders/{order_id}/status/'
+---
+
+## Overview
+
+Use this endpoint to fetch only the status details for an order. This is useful for lightweight polling without fetching full order details.
+
+

--- a/api-reference/v3/order/get.mdx
+++ b/api-reference/v3/order/get.mdx
@@ -1,0 +1,9 @@
+---
+title: 'Get Order Details'
+description: 'Retrieve order details by order ID.'
+openapi: 'GET /pg/orders/{order_id}/'
+---
+
+## Overview
+
+The Get Order endpoint allows you to retrieve complete order information including buyer details, product information, payment status, and timestamps. This is useful for order tracking and status updates.

--- a/api-reference/v3/payment/upload-verification-details.mdx
+++ b/api-reference/v3/payment/upload-verification-details.mdx
@@ -1,0 +1,44 @@
+---
+title: 'Upload Payment Verification Details'
+description: 'Upload payment verification details for a payment and update the associated order.'
+openapi: 'POST /pg/payments/{uid}/upload-verification-details/'
+---
+
+## Overview
+
+The Upload Payment Verification Details endpoint allows you to upload payment verification details for a payment. This updates the associated order with the provided information and uploads the verification details to the payment gateway.
+
+Use this endpoint when you receive a [`PAYMENT_DETAILS_MISSING`](/api-reference/v3/webhooks/payment-details-missing) webhook, or a [`VERIFICATION_NEEDED`](/api-reference/v3/webhooks/verification-needed) webhook with `verification_status` of `ACTION_REQUIRED`, and need to supply the missing or corrected verification fields.
+
+## When this applies
+
+Credits that land in a Virtual Bank Account create a payment against an order. If that order is missing any of the fields required for payment verification, the platform emits `PAYMENT_DETAILS_MISSING` listing exactly which fields are absent. This endpoint is how you supply them programmatically, rather than editing the order in the dashboard.
+
+## Verification flow
+
+<Steps>
+  <Step title="Payment recorded">
+    A credit is received and a payment is created against the order.
+  </Step>
+  <Step title="Missing fields reported">
+    If verification fields are absent, the [`PAYMENT_DETAILS_MISSING`](/api-reference/v3/webhooks/payment-details-missing) webhook fires with a `details_missing` array naming each one.
+  </Step>
+  <Step title="Supply the details">
+    Call this endpoint with the missing fields for that payment `uid`.
+  </Step>
+  <Step title="Verification outcome">
+    The [`VERIFICATION_NEEDED`](/api-reference/v3/webhooks/verification-needed) webhook reports the result — `VERIFIED`, `IN_REVIEW`, or `ACTION_REQUIRED` with the fields still needing attention.
+  </Step>
+</Steps>
+
+## Test Data
+
+When testing this API in the **sandbox environment**, you must use the following specific test values for the API to work correctly:
+
+- **buyer_name**: `John`
+- **buyer_postal_code**: `560034`
+- **product_description**: `This is a test product for test purpose.`
+
+<Note>
+  Requests using other values will not verify successfully in sandbox.
+</Note>

--- a/api-reference/v3/webhooks/payment-details-missing.mdx
+++ b/api-reference/v3/webhooks/payment-details-missing.mdx
@@ -1,0 +1,158 @@
+---
+title: "PAYMENT DETAILS MISSING"
+description: "Technical reference for the webhook sent when a payment is recorded but one or more fields that are required for payment verification are missing on the order."
+---
+
+---
+
+## Event Overview
+
+**Event Type**: `PAYMENT_DETAILS_MISSING`  
+**Category**: Payment  
+**Description**: Payment was recorded but one or more order fields required for payment verification are missing.
+
+This webhook notifies you which fields that are missing for payment verification so you can supply them via the Partner API (order update or **upload-verification-details**) or dashboard. It is used for any payment with missing verification details, including VBA transfer and regular payment success flows.
+
+### When the webhook is sent
+
+The webhook is sent **only when all** of the following are true:
+
+1. **Merchant has webhook URL** – Your merchant account (or parent, for sub-merchants) has an active API credential with a non-empty webhook URL.
+2. **At least one detail is missing** – The payment’s order is missing one or more verification fields (see [details_missing](#details_missing-field-names) below). If all six fields are present on the order, the webhook is not sent.
+
+---
+
+## Delivery Details
+
+| Attribute | Value |
+|-----------|--------|
+| **HTTP method** | `POST` |
+| **URL** | The webhook URL configured on your merchant account's API credentials |
+| **Content-Type** | `application/json` |
+| **Timeout** | 10 seconds |
+| **Retries** | Up to 5 delivery attempts (backoff: 1 min, 5 min, 15 min, 60 min) |
+
+### Headers
+
+| Header | Description |
+|--------|-------------|
+| `Content-Type` | `application/json` |
+| `User-Agent` | `Eximpe-Webhook/1.0` |
+| `X-Webhook-Event` | `PAYMENT_DETAILS_MISSING` |
+| `X-Webhook-Timestamp` | Unix timestamp (string) at the time of the request |
+| `X-Webhook-Signature` | HMAC-SHA256 signature of the request body (JSON string with keys sorted, no extra whitespace), using your API key as the secret. Hex-encoded. |
+
+**Signature verification (recommended):**  
+Compute `HMAC-SHA256(encryption_key, raw_body)` where `raw_body` is the exact UTF-8 request body as received. Compare the hex result with the `X-Webhook-Signature` header to ensure the webhook is from the platform and unchanged.
+
+---
+
+## Payload Schema
+
+<CodeGroup>
+
+```json Example Payload
+{
+  "event_type": "PAYMENT_DETAILS_MISSING",
+  "event_time": "2025-02-12T10:30:00.123456Z",
+  "version": "3.0.0",
+  "sequence_number": "550e8400-e29b-41d4-a716-446655440000",
+  "data": {
+    "order_uid": "660e8400-e29b-41d4-a716-446655440001",
+    "payment_id": "770e8400-e29b-41d4-a716-446655440002",
+    "message": "Payment recorded but verification details missing for Upload Payment Verification Details API. Supply the missing fields via the upload-verification-details API or dashboard.",
+    "details_missing": [
+      "buyer_name",
+      "product_description",
+      "buyer_address",
+      "invoice_number",
+      "buyer_postal_code",
+      "hs_code"
+    ]
+  }
+}
+```
+
+</CodeGroup>
+
+---
+
+## Field Specifications
+
+<Tabs>
+  <Tab title="Root Level Fields">
+    <ParamField path="event_type" type="string" required>
+      Always `"PAYMENT_DETAILS_MISSING"` for this webhook event
+    </ParamField>
+
+    <ParamField path="event_time" type="string" required>
+      ISO 8601 datetime when the webhook event was created
+      
+      **Example**: `"2025-02-12T10:30:00.123456Z"`
+    </ParamField>
+
+    <ParamField path="version" type="string" required>
+      Envelope version (e.g. "3.0.0")
+    </ParamField>
+
+    <ParamField path="sequence_number" type="string" required>
+      Unique identifier for this webhook event (UUID), useful for idempotency
+      
+      **Example**: `"550e8400-e29b-41d4-a716-446655440000"`
+    </ParamField>
+
+    <ParamField path="data" type="object" required>
+      Event payload: order_uid, payment_id, message, details_missing
+    </ParamField>
+  </Tab>
+
+  <Tab title="Data Object Fields">
+    <ParamField path="data.order_uid" type="string" required>
+      UID of the order for this payment
+      
+      **Example**: `"660e8400-e29b-41d4-a716-446655440001"`
+    </ParamField>
+
+    <ParamField path="data.payment_id" type="string" required>
+      UID of the payment
+      
+      **Example**: `"770e8400-e29b-41d4-a716-446655440002"`
+    </ParamField>
+
+    <ParamField path="data.message" type="string" required>
+      Human-readable message instructing you to supply the missing verification details via the upload-verification-details API or dashboard
+      
+      **Example**: `"Payment recorded but verification details missing for Upload Payment Verification Details API. Supply the missing fields via the upload-verification-details API or dashboard."`
+    </ParamField>
+
+    <ParamField path="data.details_missing" type="array" required>
+      List of **field names** that are missing on the order. Use these when updating the order via the Partner API or dashboard. See the table below for descriptions.
+      
+      **Example**: `["buyer_name", "product_description", "buyer_address", "invoice_number", "buyer_postal_code", "hs_code"]`
+    </ParamField>
+  </Tab>
+</Tabs>
+
+### details_missing field names
+
+Each element in `details_missing` is a field name that may be missing on the order. Supply the missing fields by updating the order (Partner API or dashboard) or by calling the **upload-verification-details** endpoint for that payment. The following field names may appear:
+
+| Field name | Description |
+|------------|-------------|
+| `buyer_name` | Name of the buyer/importer. |
+| `product_description` | Description of the product/goods. |
+| `buyer_address` | Buyer's address. |
+| `invoice_number` | Invoice number. |
+| `buyer_postal_code` | Buyer's postal/ZIP code. |
+| `hs_code` | HS code (or `hs_code_description` on the order). |
+
+The webhook is sent only when at least one of these fields is missing (empty or not set) on the order.
+
+---
+
+## What to Do When You Receive This Webhook
+
+1. **Respond with HTTP 2xx** (e.g. `200 OK`) as soon as you have accepted the payload, so the platform marks the delivery as successful and does not retry.
+2. **Verify the signature** using your API key and the raw request body (HMAC-SHA256, hex) to ensure authenticity.
+3. **Use `order_uid` and `payment_id`** to fetch full order/payment details from the Partner API if needed (e.g. amount, status).
+4. **Supply missing verification details** by updating the order with the missing fields (via the Partner API or dashboard) or by calling the [Upload Payment Verification Details](/api-reference/v3/payment/upload-verification-details) endpoint for that payment. The `details_missing` array lists the field names that are missing (e.g. `buyer_name`, `product_description`, `invoice_number`, `buyer_address`, `buyer_postal_code`, `hs_code`).

--- a/api-reference/v3/webhooks/verification-needed.mdx
+++ b/api-reference/v3/webhooks/verification-needed.mdx
@@ -1,0 +1,198 @@
+---
+title: "VERIFICATION NEEDED"
+description: "Technical reference for the VERIFICATION_NEEDED webhook event, including payload schema, field specifications, and implementation details."
+---
+
+---
+
+## Event Overview
+
+**Event Type**: `VERIFICATION_NEEDED`  
+**Category**: Payment Verification  
+**Description**: Payment verification status has been updated
+
+This webhook is triggered when the payment verification status is updated for collect-from-India payments (after receiving a verification update from the payment gateway).
+
+### When the webhook is sent
+
+The webhook is sent in the following scenarios:
+
+1. **Action Required** (`ACTION_REQUIRED`): Additional or corrected information is needed
+2. **Payment Verified** (`VERIFIED`): Payment has been successfully verified
+
+The webhook is created **only if**:
+- Your merchant account (or parent, for sub-merchants) has an active API credential with a non-empty webhook URL
+
+---
+
+## Delivery Details
+
+| Attribute | Value |
+|-----------|--------|
+| **HTTP method** | `POST` |
+| **URL** | The webhook URL configured on your merchant account's API credentials |
+| **Content-Type** | `application/json` |
+| **Timeout** | 10 seconds |
+| **Retries** | Up to 5 delivery attempts (backoff: 1 min, 5 min, 15 min, 60 min) |
+
+### Headers
+
+| Header | Description |
+|--------|-------------|
+| `Content-Type` | `application/json` |
+| `User-Agent` | `Eximpe-Webhook/1.0` |
+| `X-Webhook-Event` | `VERIFICATION_NEEDED` |
+| `X-Webhook-Timestamp` | Unix timestamp (string) at the time of the request |
+| `X-Webhook-Signature` | HMAC-SHA256 signature of the request body (JSON string with keys sorted, no extra whitespace), using your API key as the secret. Hex-encoded. |
+
+**Signature verification (recommended):**  
+Compute `HMAC-SHA256(encryption_key, raw_body)` where `raw_body` is the exact UTF-8 request body as received. Compare the hex result with the `X-Webhook-Signature` header to ensure the webhook is from the platform and unchanged.
+
+---
+
+## Payload Schema
+
+<CodeGroup>
+
+```json Example: Action Required
+{
+  "event_type": "VERIFICATION_NEEDED",
+  "event_time": "2025-02-13T10:30:00.123456Z",
+  "version": "3.0.0",
+  "sequence_number": "550e8400-e29b-41d4-a716-446655440000",
+  "data": {
+    "payment_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+    "order_id": "98765432-10ab-cdef-9876-543210fedcba",
+    "verification_status": "ACTION_REQUIRED",
+    "message": "Payment verification action required",
+    "action_required_fields": ["buyer_name", "hs_code"]
+  }
+}
+```
+
+```json Example: Verified
+{
+  "event_type": "VERIFICATION_NEEDED",
+  "event_time": "2025-02-13T10:30:00.123456Z",
+  "version": "3.0.0",
+  "sequence_number": "550e8400-e29b-41d4-a716-446655440001",
+  "data": {
+    "payment_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+    "order_id": "98765432-10ab-cdef-9876-543210fedcba",
+    "verification_status": "VERIFIED",
+    "message": "Payment verified",
+    "action_required_fields": []
+  }
+}
+```
+
+```json Example: In Review
+{
+  "event_type": "VERIFICATION_NEEDED",
+  "event_time": "2025-02-13T10:30:00.123456Z",
+  "version": "3.0.0",
+  "sequence_number": "550e8400-e29b-41d4-a716-446655440002",
+  "data": {
+    "payment_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+    "order_id": "98765432-10ab-cdef-9876-543210fedcba",
+    "verification_status": "IN_REVIEW",
+    "message": "Payment verification action required",
+    "action_required_fields": []
+  }
+}
+```
+
+</CodeGroup>
+
+---
+
+## Field Specifications
+
+<Tabs>
+  <Tab title="Root Level Fields">
+    <ParamField path="event_type" type="string" required>
+      Always `"VERIFICATION_NEEDED"` for this webhook event
+    </ParamField>
+
+    <ParamField path="event_time" type="string" required>
+      ISO 8601 datetime when the webhook event was created
+      
+      **Example**: `"2025-02-13T10:30:00.123456Z"`
+    </ParamField>
+
+    <ParamField path="version" type="string" required>
+      Envelope version (e.g. "3.0.0")
+    </ParamField>
+
+    <ParamField path="sequence_number" type="string" required>
+      Unique identifier for this webhook event (UUID), useful for idempotency
+      
+      **Example**: `"550e8400-e29b-41d4-a716-446655440000"`
+    </ParamField>
+
+    <ParamField path="data" type="object" required>
+      Verification status details (payment_id, order_id, verification_status, message, action_required_fields)
+    </ParamField>
+  </Tab>
+
+  <Tab title="Data Object Fields">
+    <ParamField path="data.payment_id" type="string" required>
+      UID of the payment
+      
+      **Example**: `"a1b2c3d4-e5f6-7890-abcd-ef1234567890"`
+    </ParamField>
+
+    <ParamField path="data.order_id" type="string" required>
+      UID of the order for this payment
+      
+      **Example**: `"98765432-10ab-cdef-9876-543210fedcba"`
+    </ParamField>
+
+    <ParamField path="data.verification_status" type="string" required>
+      Current verification status. One of: `IN_REVIEW`, `ACTION_REQUIRED`, `VERIFIED`
+      
+      **Example**: `"ACTION_REQUIRED"`
+    </ParamField>
+
+    <ParamField path="data.message" type="string" required>
+      Human-readable message describing the verification status
+      
+      **Example**: `"Payment verification action required"`
+    </ParamField>
+
+    <ParamField path="data.action_required_fields" type="array" required>
+      List of order field names that require merchant action. Empty array when `verification_status` is `VERIFIED` or `IN_REVIEW`.
+      
+      **Possible values**: `buyer_name`, `buyer_address`, `buyer_postal_code`, `product_description`, `invoice_number`, `invoice_file`, `hs_code`, `country_of_origin`
+      
+      **Example**: `["buyer_name", "hs_code"]`
+    </ParamField>
+  </Tab>
+</Tabs>
+
+---
+
+## What to Do When You Receive This Webhook
+
+1. **Respond with HTTP 2xx** (e.g. `200 OK`) as soon as you have accepted the payload, so the platform marks the delivery as successful and does not retry.
+2. **Verify the signature** using your API key and the raw request body (HMAC-SHA256, hex) to ensure authenticity.
+3. **Use `data.payment_id` and `data.order_id`** to reconcile with your system or fetch more details from the Partner API.
+4. **Handle based on verification status**:
+   - **`VERIFIED`**: Update your system to reflect successful verification. Payment can proceed to settlement.
+   - **`ACTION_REQUIRED`**: 
+     - Check `data.action_required_fields` to see what needs updating
+     - Notify merchant/admin about required actions
+     - Update the specified fields using the [Upload Verification Details API](/api-reference/v3/payment/upload-verification-details)
+  
+### Action Required Fields Reference
+
+When `verification_status` is `ACTION_REQUIRED`, the `action_required_fields` array contains field names that need attention:
+
+| Field Name | Description |
+|------------|-------------|
+| `buyer_name` | Full name of the buyer/importer |
+| `buyer_address` | Complete address of the buyer |
+| `buyer_postal_code` | Postal/ZIP code of the buyer |
+| `product_description` | Description of goods/services |
+| `invoice_number` | Invoice or order number |
+| `hs_code` | Harmonized System code for goods |

--- a/docs.json
+++ b/docs.json
@@ -384,6 +384,12 @@
                 ]
               },
               {
+                "group": "Payment",
+                "pages": [
+                  "api-reference/v3/payment/upload-verification-details"
+                ]
+              },
+              {
                 "group": "Merchant",
                 "pages": [
                   "api-reference/v3/merchant/create",
@@ -433,6 +439,8 @@
                 "pages": [
                   "api-reference/v3/webhooks/merchant-approved",
                   "api-reference/v3/webhooks/payment-successful",
+                  "api-reference/v3/webhooks/payment-details-missing",
+                  "api-reference/v3/webhooks/verification-needed",
                   "api-reference/v3/webhooks/payment-failed",
                   "api-reference/v3/webhooks/payment-refunded",
                   "api-reference/v3/webhooks/refund-failed",

--- a/docs.json
+++ b/docs.json
@@ -361,6 +361,12 @@
                   "integration-guide/v3/web-integration/virtual-accounts",
                   "integration-guide/v3/web-integration/lrs-compliance",
                   "integration-guide/v3/web-integration/lrs-verification",
+                  {
+                    "group": "Server to Server",
+                    "pages": [
+                      "integration-guide/v3/web-integration/s2s-upi-intent"
+                    ]
+                  },
                   "integration-guide/v3/web-integration/webhooks"
                 ]
               }
@@ -369,6 +375,14 @@
           {
             "tab": "API Reference",
             "groups": [
+              {
+                "group": "Order",
+                "pages": [
+                  "api-reference/v3/order/create",
+                  "api-reference/v3/order/get-status",
+                  "api-reference/v3/order/get"
+                ]
+              },
               {
                 "group": "Merchant",
                 "pages": [

--- a/integration-guide/v3/web-integration/s2s-upi-intent.mdx
+++ b/integration-guide/v3/web-integration/s2s-upi-intent.mdx
@@ -125,6 +125,15 @@ For S2S UPI Intent mode, the response includes:
 
 - `order_id`: Unique order identifier
 - `intent_uri`: UPI intent link that can be used to open UPI apps directly
+- `test_simulator_url`: **Sandbox only** — a URL you open in a browser to complete the payment without a real UPI app
+
+<Tip>
+  **Testing in sandbox:** the sandbox response includes an additional `test_simulator_url`. Open it in a browser to simulate the payment flow and complete the transaction without needing a real UPI app or a mobile device — useful when developing the desktop QR path or testing on a machine with no UPI app installed.
+
+  The outcome is driven by the test VPA you use in the simulator: `testsuccess@gocash` completes as **Success**, `testfailure@gocash` as **Failure**. On mobile, selecting any UPI app in the simulator triggers the corresponding flow for the test VPA.
+
+  This field is **not returned in production**.
+</Tip>
 
 **Explanation of URL Arguments**
 

--- a/integration-guide/v3/web-integration/s2s-upi-intent.mdx
+++ b/integration-guide/v3/web-integration/s2s-upi-intent.mdx
@@ -1,0 +1,286 @@
+---
+title: "S2S UPI Intent"
+description: "Enable direct UPI payments without redirection using EximPe’s server-to-server UPI intent flow"
+---
+
+# Introduction
+
+The Server-to-Server (S2S) UPI Intent integration eliminates redirection hops by initiating transactions from your backend. Deliver a seamless checkout experience while maintaining control and confidence for your customers.
+
+<CardGroup cols={3}>
+  <Card title="No Redirect Hops" icon="arrow-right" href="#step-2-initiate-payment">
+    Initiate transactions directly from your server to improve user experience
+  </Card>
+  <Card title="Flexible Intent Invocation" icon="phone" href="#step-3-invoke-upi-intent">
+    Call the Initiate Payment API when the user selects an app (Mobile) or scans a QR code (Desktop)
+  </Card>
+  <Card title="Robust Server Callbacks" icon="server" href="#step-4-eximpe-sends-webhook-response">
+    Receive asynchronous status updates via server-to-server callbacks
+  </Card>
+</CardGroup>
+
+### Intent Invocation
+
+Intent invocation is simply the act of packaging your UPI payment details (amount, payee VPA, reference, etc.) into a deep-link URI and then launching the user’s UPI app directly from your front end. With a **specific intent**, you target a known app (e.g. Google Pay), while a **generic intent** lets Android show an app picker (on iOS it falls back to the default handler), all without bouncing users through extra web redirects.
+
+## Prerequisites
+
+Before you begin, ensure you have:
+
+- **Credentials**: Your Client ID and Client Secret
+- **Domain Whitelist**: Whitelisted your website domain for integration
+- **Webhook URL**: A secure endpoint to receive payment status updates
+- **Callback URL**: A publicly accessible URL configured in your EximPe dashboard for server-to-server callbacks.
+- **cURL or HTTP Client**: Capability to make HTTPS `POST` and `GET` requests from your server.
+- **UPI Knowledge**: Familiarity with UPI intent URL parameters and encoding.
+
+The following steps allow you to integrate the server-to-server UPI intent:
+
+1. **User selects UPI App (Mobile) or QR Code (Desktop)** on your frontend.
+2. **Frontend calls your Backend** to initiate the payment.
+3. **Backend calls EximPe Initiate Payment API** to get the `intent_uri`.
+4. **Backend returns `intent_uri`** to the Frontend.
+5. **Frontend invokes the UPI Intent** on the customer’s device.
+6. **Check UPI transaction status** via API or Webhook.
+
+## Step 1: Payment Page UI
+
+Design your payment page to allow users to select their preferred UPI method.
+
+#### Desktop (PC)
+
+On desktop browsers, prepare a container to display a **QR Code**. When the user proceeds, you will generate this QR code from the intent URI.
+
+#### Mobile (Android & iOS)
+
+<img src="/images/upi-app-selection.png" alt="UPI App Selection UI" style={{ width: '200px', marginBottom: '20px' }} />
+
+For mobile devices, design a list of popular UPI apps (like Google Pay, PhonePe, Paytm) for the buyer to select from. This provides the best user experience.
+
+## Step 2: Initiate Payment
+
+When the user clicks on a specific UPI app icon (e.g., Google Pay) on mobile or selects "Show QR" on desktop, your backend should call this API to generate the `intent_uri`.
+
+#### Sample UPI Intent Request Body
+
+```json
+{
+  "amount": "1000.00",
+  "collection_mode": "s2s",
+  "upi_flow_type": "intent",
+  "currency": "INR",
+  "reference_id": "S2SI_U8MEIT",
+  "mop_type": "upi",
+  "buyer": {
+    "name": "John Doe",
+    "email": "john.doe@example.com",
+    "phone": "+919876543210",
+    "address": {
+      "line_1": "123 Main Street",
+      "line_2": "Apt 4B",
+      "city": "City",
+      "state": "State",
+      "postal_code": "123456"
+    },
+    "ip_address": "192.168.1.100",
+    "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
+  },
+  "product": {
+    "name": "Sample Product",
+    "description": "This is a sample product description",
+    "hs_code": "98051000",
+    "hs_code_description": "Portable automatic data processing machines",
+    "type_of_goods": "physical_goods"
+  },
+  "invoice": {
+    "number": "INV_V9TZZ3",
+    "date": "2025-07-08"
+  }
+}
+```
+
+<Note>
+  For the S2S UPI Intent request, you must include these additional parameters beyond the standard checkout fields:
+
+  - `collection_mode`: must be set to `"s2s"`
+  - `upi_flow_type`: must be set to `"intent"`
+  - `buyer.ip_address`: the customer’s device IP address
+  - `buyer.user_agent`: the customer’s browser or app user-agent string
+</Note>
+
+### S2S UPI Intent Response
+
+```json
+{
+  "success": true,
+  "message": "S2S UPI Request created successfully",
+  "data": {
+    "intent_uri": "pa=kk.payutest@hdfcbank&pn=&tr=403993715534292371&tid=PPPL403993715534292371080725205418&am=1000.00&cu=INR&tn=UPIIntent",
+    "order_id": "OD2000992103"
+  }
+}
+```
+
+For S2S UPI Intent mode, the response includes:
+
+- `order_id`: Unique order identifier
+- `intent_uri`: UPI intent link that can be used to open UPI apps directly
+
+**Explanation of URL Arguments**
+
+| Argument | Example Value   | Required | Description                                                                                      |
+| -------- | --------------- | -------- | ------------------------------------------------------------------------------------------------ |
+| `pa`     | `merchant@bank` | Yes      | Payee VPA (Virtual Payment Address) — the merchant's UPI ID that will receive the payment        |
+| `pn`     | `Merchant Name` | Yes      | Payee Name — the display name of the merchant                                                    |
+| `am`     | `100.00`        | No       | Amount — the payment amount (decimal, up to two places)                                          |
+| `cu`     | `INR`           | Yes      | Currency — must be `INR` for Indian rupees                                                       |
+| `tr`     | `TXN12345`      | Yes      | Transaction Reference ID — unique identifier for this transaction (for reconciliation)           |
+| `tid`    | `TXNID98765`    | No       | Transaction ID — a unique transaction ID (sometimes required by specific apps, e.g., Google Pay) |
+| `tn`     | `Order Payment` | No       | Transaction Note — a short note or description for the payment                                   |
+
+## Step 3: Invoke UPI Intent
+
+The method for invoking a UPI payment depends on the customer's device and operating system.
+
+#### Desktop (PC)
+
+On desktop browsers, use the `intent_uri` to generate a **QR Code**. The user can then scan this code with their mobile UPI app to complete the payment.
+
+**Implementation:**
+1. Prefix the `intent_uri` with `upi://pay?`
+2. Use a QR code generation library or API to convert the full URI into a QR code image.
+3. Display the QR code prominently with instructions like "Scan to Pay".
+
+***PC Specific App Format***:
+```text
+upi://pay?<intent_uri>
+```
+
+
+**Examples:**
+
+<CodeGroup>
+```text
+upi://pay?pa=merchant@bank&pn=Merchant&am=1.00&cu=INR&tr=TXN123
+```
+</CodeGroup>
+
+#### Mobile (Android & iOS)
+
+For mobile devices, use the `intent_uri` to directly launch the customer's UPI application. This provides a seamless experience without manual data entry.
+
+##### 1. Specific App Invocation (Android & iOS)
+
+To target a specific app, use the following schemes:
+
+| UPI App      | Android Package Name (for Intent URL)    | iOS URL Scheme Prefix |
+| ------------ | ---------------------------------------- | --------------------- |
+| Google Pay   | `com.google.android.apps.nbu.paisa.user` | `gpay://upi/pay?`     |
+| PhonePe      | `com.phonepe.app`                        | `phonepe://upi/pay?`  |
+| BHIM         | `in.org.npci.upiapp`                     | `bhim://upi/pay?`     |
+| Paytm        | `net.one97.paytm`                        | `paytmmp://upi/pay?`  |
+| Amazon Pay   | `in.amazon.mShop.android.shopping`       | `amazonpay://upi/pay?`|
+| CRED         | `com.dreamplug.androidapp`               | `credpay://upi/pay?`  |
+| Supermoney   | `money.super.payments`                   | `super://pay?`        |
+| Fi Money     | `com.fi.money`                           | `fi://upi/pay?`       |
+| Jupiter      | `money.jupiter`                          | `jupiter://upi/pay?`  |
+| Slice        | `indwin.c3.shareapp`                     | `slice://upi/pay?`    |
+
+**Android Specific App Format:**
+```
+intent://pay?<intent_uri>#Intent;scheme=upi;package=<package_name>;end;
+```
+
+**Examples:**
+
+<CodeGroup>
+```text Google Pay
+intent://pay?pa=merchant@bank&pn=Merchant&am=1.00&cu=INR&tr=TXN123#Intent;scheme=upi;package=com.google.android.apps.nbu.paisa.user;end;
+```
+
+```text PhonePe
+intent://pay?pa=merchant@bank&pn=Merchant&am=1.00&cu=INR&tr=TXN123#Intent;scheme=upi;package=com.phonepe.app;end;
+```
+
+```text BHIM
+intent://pay?pa=merchant@bank&pn=Merchant&am=1.00&cu=INR&tr=TXN123#Intent;scheme=upi;package=in.org.npci.upiapp;end;
+```
+
+```text Paytm
+intent://pay?pa=merchant@bank&pn=Merchant&am=1.00&cu=INR&tr=TXN123#Intent;scheme=upi;package=net.one97.paytm;end;
+```
+</CodeGroup>
+
+**iOS Specific App Format:**
+```
+<scheme_prefix><intent_uri>
+```
+
+**Examples:**
+
+<CodeGroup>
+```text Google Pay
+gpay://upi/pay?pa=merchant@bank&pn=Merchant&am=1.00&cu=INR&tr=TXN123
+```
+
+```text PhonePe
+phonepe://upi/pay?pa=merchant@bank&pn=Merchant&am=1.00&cu=INR&tr=TXN123
+```
+
+```text BHIM
+bhim://upi/pay?pa=merchant@bank&pn=Merchant&am=1.00&cu=INR&tr=TXN123
+```
+
+```text Paytm
+paytmmp://upi/pay?pa=merchant@bank&pn=Merchant&am=1.00&cu=INR&tr=TXN123
+```
+</CodeGroup>
+
+##### 2. Generic Intent Invocation
+
+If you want to allow the user to choose from any available UPI app or use their default handler, use the following scheme:
+
+| Type           | Scheme Prefix | Description                                      |
+| -------------- | ------------- | ------------------------------------------------ |
+| **General UPI**| `upi://pay?`  | Launches the system's default UPI handler        |
+
+**Example:**
+```text
+upi://pay?pa=merchant@bank&pn=Merchant&am=1.00&cu=INR&tr=TXN123
+```
+
+<Note>
+  - **On Android**: Invoking `upi://pay?` will open the system's app tray (the "Complete action using" dialog), allowing the buyer to select from all installed UPI apps.
+
+  <img src="/images/android-app-tray.jpg" alt="Android App Tray UI" style={{ width: '200px' }} />
+
+  - **On iOS**: Invoking `upi://pay?` will directly open the default UPI app configured on the device.
+</Note>
+
+<Note>
+  **Pro Tip:** For the best user experience, detect the user's device type. Show a QR code on Desktop and a list of UPI apps (or a "Pay via UPI" button) on Mobile.
+</Note>
+
+### Step 3: Check UPI Transaction Status
+
+Invoke the **Order Status API** to retrieve the status of the UPI transaction:
+
+```bash [expandable]
+curl -X GET https://api-pacb.eximpe.com/pg/orders/{order_id}/status/ \
+  -H "X-Client-ID: YOUR_CLIENT_ID" \
+  -H "X-Client-Secret: YOUR_CLIENT_SECRET" \
+  -H "X-API-Version: 3.0.0"
+```
+
+<Note>
+  For detailed parameters and response formats, see the [Get Order API](/api-reference/v3/order/get)
+</Note>
+
+### Step 4: EximPe sends webhook response
+
+EximPe can also send a webhook response whenever the transaction status gets updated.
+
+For more information, see the [Payment Successful response](/api-reference/v3/webhooks/payment-successful)
+
+
+---

--- a/integration-guide/v3/web-integration/webhooks.mdx
+++ b/integration-guide/v3/web-integration/webhooks.mdx
@@ -39,6 +39,14 @@ EximPe sends webhooks for these key events:
     **When:** A credit lands in a VBA and a payment is created<br/>
     **Use Case:** Begin LRS verification for the credit
   </Card>
+  <Card title="Payment Details Missing" icon="triangle-exclamation">
+    **When:** A credit lands but the order is missing fields required for verification<br/>
+    **Use Case:** Supply them via [Upload Payment Verification Details](/api-reference/v3/payment/upload-verification-details)
+  </Card>
+  <Card title="Verification Needed" icon="file-circle-check">
+    **When:** Verification status changes to `VERIFIED`, `IN_REVIEW`, or `ACTION_REQUIRED`<br/>
+    **Use Case:** Track the outcome, or correct the fields still flagged
+  </Card>
   <Card title="Payment Failed" icon="x">
     **When:** A credit could not be processed<br/>
     **Use Case:** Investigate and reconcile


### PR DESCRIPTION
## What

Restores two payment flows to the v3 docs:

1. **S2S UPI Intent** — integration guide + the Order API reference pages it depends on.
2. **Payment verification details** — the `upload-verification-details` endpoint and its two webhooks.

Rebased onto current `main`.

## Context — why the UPI Intent files were gone

Two earlier PRs removed this surface from v3:

- **#52** (`docs(v3): trim API reference to match nav`) deleted `api-reference/v3/order/{create,get-status,get}.mdx` along with ~27 other v3 API pages.
- **#58** (`docs(v3): rewrite integration guide for the VBA + LRS collection model`) deleted `integration-guide/v3/web-integration/s2s-upi-intent.mdx` and replaced the "Payment Integration" nav group with "Collecting Payments".

This PR reverses that **specifically for the UPI Intent flow**. Card, netbanking, hosted checkout, payment links and BIN lookup remain removed from v3.

## Changes

### 1. S2S UPI Intent

| File | Change |
|---|---|
| `integration-guide/v3/web-integration/s2s-upi-intent.mdx` | Restored. `X-API-Version` bumped `2.0.0` → `3.0.0`; two links re-pointed at v3 targets |
| `api-reference/v3/order/{create,get-status,get}.mdx` | Restored — the guide's Initiate Payment and Order Status steps depend on these |

### 2. Payment verification details

This flow existed in v2 but was never present in v3. It is **directly relevant to the v3 VBA model** — `PAYMENT_DETAILS_MISSING` explicitly covers VBA transfer credits, not just card/UPI payments.

| File | Change |
|---|---|
| `api-reference/v3/payment/upload-verification-details.mdx` | New — `POST /pg/payments/{uid}/upload-verification-details/`, with the four-step flow and sandbox test values |
| `api-reference/v3/webhooks/payment-details-missing.mdx` | New — fires when a credit is recorded but the order is missing verification fields |
| `api-reference/v3/webhooks/verification-needed.mdx` | New — reports `VERIFIED` / `IN_REVIEW` / `ACTION_REQUIRED` |
| `integration-guide/v3/web-integration/webhooks.mdx` | Both events added to Supported Events |

Webhook envelope examples use `"version": "3.0.0"` to match the existing v3 webhook pages.

### 3. Housekeeping

| File | Change |
|---|---|
| `docs.json` | Added "Server to Server" group (v3 → Collecting Payments), "Order" and "Payment" groups, and the two webhooks to the v3 nav |
| `openapi/v2/openapi.json` | Deleted — 0-byte invalid JSON, unreferenced, breaks the Mintlify build |

## Verified

Local dev server, all 200:

```
integration-guide/v3/web-integration/s2s-upi-intent            200
integration-guide/v3/web-integration/webhooks                  200
api-reference/v3/order/create                                  200
api-reference/v3/order/get-status                              200
api-reference/v3/order/get                                     200
api-reference/v3/payment/upload-verification-details           200
api-reference/v3/webhooks/payment-details-missing              200
api-reference/v3/webhooks/verification-needed                  200
```

`docs.json` parses, and every internal link added resolves. **Not visually reviewed in a browser** — verification is build + HTTP status only.

## Please check

- **Cross-version link.** `api-reference/v3/order/create.mdx` documents `netbanking_details.bank_name` and links to the supported-banks list. That list lived on the v3 netbanking page, which #58 deleted, so both links (lines 159 and 445) now point at the **v2** page. Options: leave as-is, drop the netbanking fields from the v3 page, or re-home the bank list in v3.
- **`3.0.0` vs `v3.0.0`.** This uses bare `3.0.0` throughout, matching existing v3 webhook pages. `api-reference/v3/bin-lookup/lookup.mdx` used the prefixed `v3.0.0` form before #52 removed it. Someone with API access should confirm which the service accepts.
- **Test data.** v2's upload-verification-details page links to a v3 test-data page that #58 deleted. I kept the three sandbox values inline rather than linking cross-version — inconsistent with the netbanking decision above, so worth settling both together.
- **Does re-adding UPI Intent fit the v3 VBA + LRS model?** #58 was a deliberate restructure; this partially reverses it. Worth a nod from whoever drove that. (The verification-details flow is on-model regardless.)

## Separately

The pinned `mintlify@4.0.x` fails with `TypeError: (intermediate value) is not iterable` even after the empty-spec removal. `npx mint@latest` works — dependency likely needs bumping. Not touched here.
