### PR TITLE
docs(v3): drop the TCS declarations and quote TCS on the principal

### DIFF
--- a/integration-guide/v3/getting-started/faqs.mdx
+++ b/integration-guide/v3/getting-started/faqs.mdx
@@ -96,7 +96,7 @@ LRS is reported against the **PAN of the debited account**. A credit from a thir
 For education funded from the remitter's own funds, TCS is **2% on the amount above ₹10,00,000** of the remitter's cumulative LRS in a financial year — the first ₹10 lakh each year is TCS-free.
 
 - The threshold is measured against **EximPe's own LRS counter** on the remittance amount. There is no buyer self-declaration.
-- The tax is charged on the **settlement base** — the remittance less EximPe's fee and the GST on that fee. On the payment that crosses ₹10 lakh, the fee is netted off the above-threshold slice pro-rata.
+- The tax is charged on the **remittance amount itself**. EximPe's fee and the GST on it are billed on top and do not reduce it. On the payment that crosses ₹10 lakh, the slice above the threshold is taxed in full.
 
 [Quote LRS Amount](/api-reference/v3/lrs/quote) returns the exact TCS and the all-in `total_payable_inr` — principal + EximPe's fee + GST + TCS. Collect exactly that. The AD bank deposits the tax against the remitter's PAN, and the remitter reclaims it as a tax credit (it reflects in their Form 26AS / TCS certificate).
 

--- a/integration-guide/v3/getting-started/faqs.mdx
+++ b/integration-guide/v3/getting-started/faqs.mdx
@@ -89,7 +89,7 @@ Yes — but **the parent is then the remitter**. Their PAN is used and their acc
 
 ### Why must the money come from the remitter's own account?
 
-LRS is reported against the **PAN of the debited account**. A credit from a third party's account cannot be settled on someone else's PAN. Enforce own-account payment in your UX — a mismatch puts the payment **On Hold**.
+LRS is reported against the **PAN of the debited account**. A credit from a third party's account cannot be settled on someone else's PAN. Enforce own-account payment in your UX — a mismatch keeps the payment in **Action Required** with `reason: SENDER_NAME_MISMATCH`, and it clears only by re-declaring the actual account holder as the remitter.
 
 ### How is TCS calculated?
 

--- a/integration-guide/v3/getting-started/faqs.mdx
+++ b/integration-guide/v3/getting-started/faqs.mdx
@@ -95,18 +95,18 @@ LRS is reported against the **PAN of the debited account**. A credit from a thir
 
 For education funded from the remitter's own funds, TCS is **2% on the amount above ₹10,00,000** of the remitter's cumulative LRS in a financial year — the first ₹10 lakh each year is TCS-free.
 
-- If the remitter has **already exceeded** ₹10 lakh (`tcs_threshold_breached: true`), TCS applies to the **full** amount of this payment.
-- If **not exceeded**, EximPe computes against its record of the remitter's LRS through us. If this payment itself crosses the threshold, TCS applies only to the portion **above** it.
+- The threshold is measured against **EximPe's own LRS counter** on the remittance amount. There is no buyer self-declaration.
+- The tax is charged on the **settlement base** — the remittance less EximPe's fee and the GST on that fee. On the payment that crosses ₹10 lakh, the fee is netted off the above-threshold slice pro-rata.
 
-[Quote LRS Amount](/api-reference/v3/lrs/quote) returns the exact TCS; collect it alongside the principal. The AD bank deposits the tax against the remitter's PAN, and the remitter reclaims it as a tax credit (it reflects in their Form 26AS / TCS certificate).
+[Quote LRS Amount](/api-reference/v3/lrs/quote) returns the exact TCS and the all-in `total_payable_inr` — principal + EximPe's fee + GST + TCS. Collect exactly that. The AD bank deposits the tax against the remitter's PAN, and the remitter reclaims it as a tax credit (it reflects in their Form 26AS / TCS certificate).
 
 ### Do I have to call the quote API?
 
-It is optional but strongly recommended. Quoting reserves nothing and can be re-run freely, so show the buyer the tax-inclusive total before they transfer — otherwise they under-pay and you have to handle a shortfall.
+It is optional but strongly recommended. Quoting reserves nothing and can be re-run freely, so show the buyer the all-in total (principal + EximPe's fee + GST + TCS) before they transfer — otherwise they under-pay and you have to handle a shortfall.
 
 ### What declarations does the buyer affirm?
 
-Two, both of which must be affirmed for the payment to proceed: one covering **resident-individual status, the LRS limit, and source of funds**; and one covering **TCS and the ₹10 lakh threshold**. They map onto the `declarations` object and the `tcs_threshold_breached` flag on [Submit LRS Verification](/api-reference/v3/lrs/submit-verification). See [LRS & Compliance](/integration-guide/v3/web-integration/lrs-compliance#the-declarations) for the exact wording.
+Three, all of which must be affirmed for the payment to proceed: **resident-individual status, the LRS limit, and source of funds**. They map onto the `declarations` object on [Submit LRS Verification](/api-reference/v3/lrs/submit-verification). The TCS acknowledgement (`declarations.tcs`) and the ₹10 lakh self-declaration (`tcs_threshold_breached`) are no longer collected — EximPe determines the threshold from its own counter. See [LRS & Compliance](/integration-guide/v3/web-integration/lrs-compliance#the-declarations) for the exact wording.
 
 ### Which purpose codes are supported?
 

--- a/integration-guide/v3/web-integration/collection-overview.mdx
+++ b/integration-guide/v3/web-integration/collection-overview.mdx
@@ -52,7 +52,7 @@ This is an **API-only** cross-border collection rail. The buyer never sees an Ex
     Quote the TCS and all-in total for the remittance against the buyer's LRS usage.
   </Step>
   <Step title="Upload documents & submit verification">
-    Upload the supporting documents, then submit the remitter, purpose code, invoice, declarations, and collected TCS. The payment moves to **Under Review** (or stays in **Action Required** / goes **On Hold** if something is missing).
+    Upload the supporting documents, then submit the remitter, purpose code, invoice, declarations, the principal, and the collected TCS. The payment moves to **Under Review**, or stays in **Action Required** if something is missing or short.
   </Step>
   <Step title="Settle & reconcile">
     Once cleared, funds are settled to the beneficiary abroad. Track via the [Settlement APIs](/api-reference/v3/settlement/list) and [Payment Settled](/api-reference/v3/webhooks/payment-settled) webhook.

--- a/integration-guide/v3/web-integration/lrs-compliance.mdx
+++ b/integration-guide/v3/web-integration/lrs-compliance.mdx
@@ -15,7 +15,7 @@ You own the customer relationship and everything the customer sees; EximPe is th
 | :--- | :--- |
 | Own the entire customer-facing experience — EximPe shows the customer no screen. | Issues a virtual account, verifies eligibility, computes TCS, files settlement with the AD bank. |
 | Onboard and identify the remitter; collect their details and documents. | Verifies PAN validity, residency affirmation, documents, and declarations. |
-| Provide the INR amount to collect (you handle FX). | Adds only the tax — no FX risk from the EximPe leg. |
+| Provide the INR amount to collect (you handle FX). | Adds our fee and the tax on top — no FX risk from the EximPe leg. |
 
 <Note>
   You onboard the **universities** you serve as sub-merchants — each configured with its own settlement details. Collections, settlements, and balances are tracked **per university**. A partner can onboard one or many.
@@ -44,34 +44,42 @@ You own the customer relationship and everything the customer sees; EximPe is th
 
 ### The declarations
 
-The four regulatory requirements — resident-individual status, the LRS limit, source of funds, and TCS — can be presented to the buyer as **two declarations**. Both must be affirmed for the payment to proceed.
+Three regulatory requirements — resident-individual status, the LRS limit, and source of funds — are affirmed by the buyer and passed to us. All three must be affirmed for the payment to proceed.
 
-**Declaration 1 — Eligibility, LRS limit & source of funds**
+**Declaration — Eligibility, LRS limit & source of funds**
 
 > "I am a resident individual under FEMA, and this remittance is under the Liberalised Remittance Scheme. My total LRS this financial year, including this remittance, is within the permitted limit of USD 250,000, and it is for a permitted purpose (not one prohibited under FEMA/RBI). The funds are from my own legitimate sources and comply with FEMA, RBI, AML and income-tax laws. The information in this declaration is true and complete and I accept sole responsibility for its accuracy."
 
-**Declaration 2 — TCS / ₹10 lakh threshold**
-
-> "I have ☐ already exceeded / ☐ not exceeded ₹10,00,000 in LRS remittances this financial year across all banks and channels. I understand that TCS may be collected as applicable under the Income-tax Act, and that the PAN I have furnished is correct."
-
-These map onto the `declarations` object and the `tcs_threshold_breached` flag on [Submit LRS Verification](/api-reference/v3/lrs/submit-verification):
+These map onto the `declarations` object on [Submit LRS Verification](/api-reference/v3/lrs/submit-verification):
 
 | Declaration | API field |
 | :--- | :--- |
 | Resident individual | `declarations.resident_in_india` |
 | Under the LRS limit | `declarations.lrs` |
 | Source of funds | `declarations.source_of_funds` |
-| TCS understanding | `declarations.tcs` |
-| ₹10 lakh already exceeded? | `tcs_threshold_breached` (`true` = already exceeded) |
+
+<Note>
+  **The ₹10 lakh TCS question is no longer collected.** The buyer's self-declaration that they had already crossed ₹10 lakh elsewhere (`tcs_threshold_breached`) and the TCS acknowledgement (`declarations.tcs`) have both been removed from the quote and submit payloads. EximPe determines the threshold from its own LRS counter. Requests that still send either field are accepted and ignored, not rejected. Keep showing the buyer that TCS is being collected — it is a disclosure, not an API field.
+</Note>
 
 ## Tax at source (TCS)
 
-For education funded from the remitter's own funds, **TCS is 2% on the amount above ₹10,00,000** of LRS in a financial year — the first ₹10 lakh each year is TCS-free. Declaration 2's ₹10 lakh answer drives the calculation:
+For education funded from the remitter's own funds, **TCS is 2% on the amount above ₹10,00,000** of LRS in a financial year — the first ₹10 lakh each year is TCS-free. EximPe's own LRS counter decides the threshold; there is no buyer self-declaration:
 
-- **Already exceeded ₹10 lakh** (`tcs_threshold_breached: true`) → TCS applies to the **full** amount of this payment.
-- **Not exceeded** → EximPe computes against its record of the remitter's LRS through us. If this payment itself crosses ₹10 lakh, TCS applies only to the portion **above** the threshold.
+- **Counter already past ₹10 lakh** → the whole of this payment is taxable.
+- **This payment crosses ₹10 lakh** → only the portion **above** the threshold is taxable.
+- **Still under ₹10 lakh** → nil.
 
-[Quote LRS Amount](/api-reference/v3/lrs/quote) returns the exact TCS; you collect it with the principal. The AD bank deposits the tax against the remitter's PAN, and the remitter reclaims it as a tax credit (it reflects in their Form 26AS / TCS certificate).
+Two different bases are in play, and they are deliberately different numbers:
+
+| Base | What it is | What it drives |
+| :--- | :--- | :--- |
+| Principal | The remittance amount — the money that goes abroad | The ₹10 lakh counter and the threshold test |
+| Settlement base | Principal − EximPe's fee − GST on that fee | The tax itself |
+
+On the payment that crosses the threshold, the fee is netted off the taxable slice pro-rata, so the fee charged on the nil-rated first ₹10 lakh does not reduce the tax.
+
+The buyer therefore pays **principal + EximPe's fee + GST on that fee + TCS**, so the full principal settles onward. [Quote LRS Amount](/api-reference/v3/lrs/quote) returns that all-in total in `total_payable_inr` — collect exactly it. The AD bank deposits the tax against the remitter's PAN, and the remitter reclaims it as a tax credit (it reflects in their Form 26AS / TCS certificate).
 
 <Note>
   EximPe tracks LRS usage and **refuses any remittance that would breach the USD 250,000 annual cap** on the data available to us; the AD bank is the wider backstop at settlement.

--- a/integration-guide/v3/web-integration/lrs-compliance.mdx
+++ b/integration-guide/v3/web-integration/lrs-compliance.mdx
@@ -70,14 +70,9 @@ For education funded from the remitter's own funds, **TCS is 2% on the amount ab
 - **This payment crosses ₹10 lakh** → only the portion **above** the threshold is taxable.
 - **Still under ₹10 lakh** → nil.
 
-Two different bases are in play, and they are deliberately different numbers:
+The tax is charged on the **principal** — the remittance amount, the money that goes abroad. EximPe's fee and the GST on it are billed **on top of** the principal, not taken out of it, so they never reduce the taxable amount. The same principal drives the ₹10 lakh counter, the threshold test and the tax, so the three can never disagree.
 
-| Base | What it is | What it drives |
-| :--- | :--- | :--- |
-| Principal | The remittance amount — the money that goes abroad | The ₹10 lakh counter and the threshold test |
-| Settlement base | Principal − EximPe's fee − GST on that fee | The tax itself |
-
-On the payment that crosses the threshold, the fee is netted off the taxable slice pro-rata, so the fee charged on the nil-rated first ₹10 lakh does not reduce the tax.
+On the payment that crosses the threshold, the slice above ₹10 lakh is taxed **in full**.
 
 The buyer therefore pays **principal + EximPe's fee + GST on that fee + TCS**, so the full principal settles onward. [Quote LRS Amount](/api-reference/v3/lrs/quote) returns that all-in total in `total_payable_inr` — collect exactly it. The AD bank deposits the tax against the remitter's PAN, and the remitter reclaims it as a tax credit (it reflects in their Form 26AS / TCS certificate).
 

--- a/integration-guide/v3/web-integration/lrs-verification.mdx
+++ b/integration-guide/v3/web-integration/lrs-verification.mdx
@@ -71,7 +71,9 @@ Document `type` values depend on the purpose code — e.g. `offer_letter`, `fee_
 
 ## Step 4: Submit Verification Details
 
-Finally, submit the remaining details for the payment: the remitter, purpose code, invoice, address, contact, declarations, collected TCS, and the document `ref`s. EximPe runs the checks (declarations, documents, sender-name match, TCS, money-match), posts the payment to the buyer's LRS counter, and advances it. The money-match expects the credit to cover the **principal, EximPe's fee, the GST on that fee and the TCS** — the same all-in total the quote returned.
+Finally, submit the remaining details for the payment: the remitter, purpose code, invoice, address, contact, declarations, the `principal`, the collected TCS, and the document `ref`s. EximPe runs the checks (declarations, documents, sender-name match, TCS, money-match), posts the payment to the buyer's LRS counter, and advances it. The money-match expects the credit to cover the **principal, EximPe's fee, the GST on that fee and the TCS** — the same all-in total the quote returned.
+
+`principal` is this payment's remitted amount — what settles onward, what posts to the ₹10 lakh LRS counter, and what TCS is charged on. It is **not** `invoice.amount`: the invoice total is metadata for the settlement file and may be met across several payments, each with its own principal.
 
 ```bash
 curl -X POST 'https://api-pacb-uat.eximpe.com/pg/lrs/verify/' \
@@ -85,6 +87,7 @@ curl -X POST 'https://api-pacb-uat.eximpe.com/pg/lrs/verify/' \
     "invoice": { "number": "INV-2025-0091", "date": "2025-07-01", "amount": 1200000 },
     "address": { "address1": "12 MG Road", "city": "Bengaluru", "state": "Karnataka", "pincode": "560001" },
     "contact": { "email": "john@example.com", "mobile": "9876543210" },
+    "principal": 1200000,
     "tcs": 4000.00,
     "declarations": { "resident_in_india": true, "lrs": true, "source_of_funds": true },
     "documents": [ { "type": "offer_letter", "ref": "<ref-from-step-3>" } ]
@@ -96,8 +99,9 @@ The response reports the resulting state:
 | `status` | Meaning |
 | :--- | :--- |
 | `under_review` | Checks passed; posted to the LRS counter and awaiting bank processing. |
-| `action_required` | Something is missing — see the `missing` array and `outstanding` amount, fix, and resubmit. |
-| `on_hold` | Needs manual attention (e.g. the sender is not the PAN holder). |
+| `action_required` | Something is missing — see the `missing` array and `outstanding` amount, fix, and resubmit. A non-null `reason` (e.g. `SENDER_NAME_MISMATCH`) says the credit's sender is not the declared PAN holder. |
+
+LRS has no On Hold state: every outcome that does not advance stays in `action_required` and is cleared by re-submitting.
 
 <Warning>
   When the remitter's `relation` is not `SELF` (e.g. a parent paying for a student), you must also include `primary_person` (name, dob, passport number) for the person the remittance is for.

--- a/integration-guide/v3/web-integration/lrs-verification.mdx
+++ b/integration-guide/v3/web-integration/lrs-verification.mdx
@@ -35,14 +35,14 @@ A non-matching or rejected PAN returns `verified: false` with a `reason` (e.g. `
 
 ## Step 2: Quote the TCS
 
-Show the buyer a complete, tax-inclusive amount before they pay. The quote returns the TCS due and the all-in total to collect. For education from the buyer's own funds, TCS is **2% on the amount above ₹10,00,000** of the remitter's cumulative LRS this financial year — the first ₹10 lakh each year is TCS-free. This quotes against the LRS usage EximPe can see and reserves nothing, so you can re-quote freely.
+Show the buyer a complete, tax-inclusive amount before they pay. The quote returns the TCS due and the all-in total to collect. For education from the buyer's own funds, TCS is **2% on the amount above ₹10,00,000** of the remitter's cumulative LRS this financial year — the first ₹10 lakh each year is TCS-free. The threshold is measured against the LRS usage EximPe can see, with no buyer self-declaration; the tax itself is charged on the settlement base (the remittance less EximPe's fee and the GST on it). `total_payable_inr` is **remittance + EximPe's fee + GST + TCS** — collect exactly that. Quoting reserves nothing, so you can re-quote freely.
 
 ```bash
 curl -X POST 'https://api-pacb-uat.eximpe.com/pg/lrs/quote/' \
   -H 'X-Client-ID: <client_id>' -H 'X-Client-Secret: <client_secret>' \
   -H 'X-Merchant-ID: <sub_merchant_id>' -H 'X-API-Version: 3.0.0' \
   -H 'Content-Type: application/json' \
-  -d '{ "pan": "ABCDE1234F", "amount": 1200000, "purpose_code": "S0305", "tcs_threshold_breached": false }'
+  -d '{ "pan": "ABCDE1234F", "amount": 1200000, "purpose_code": "S0305" }'
 ```
 
 The `purpose_code` must be one your settling entity is enabled for (its allowlist).
@@ -71,7 +71,7 @@ Document `type` values depend on the purpose code — e.g. `offer_letter`, `fee_
 
 ## Step 4: Submit Verification Details
 
-Finally, submit the remaining details for the payment: the remitter, purpose code, invoice, address, contact, declarations, collected TCS, and the document `ref`s. EximPe runs the checks (declarations, documents, sender-name match, TCS, money-match), posts the payment to the buyer's LRS counter, and advances it.
+Finally, submit the remaining details for the payment: the remitter, purpose code, invoice, address, contact, declarations, collected TCS, and the document `ref`s. EximPe runs the checks (declarations, documents, sender-name match, TCS, money-match), posts the payment to the buyer's LRS counter, and advances it. The money-match expects the credit to cover the **principal, EximPe's fee, the GST on that fee and the TCS** — the same all-in total the quote returned.
 
 ```bash
 curl -X POST 'https://api-pacb-uat.eximpe.com/pg/lrs/verify/' \
@@ -85,8 +85,8 @@ curl -X POST 'https://api-pacb-uat.eximpe.com/pg/lrs/verify/' \
     "invoice": { "number": "INV-2025-0091", "date": "2025-07-01", "amount": 1200000 },
     "address": { "address1": "12 MG Road", "city": "Bengaluru", "state": "Karnataka", "pincode": "560001" },
     "contact": { "email": "john@example.com", "mobile": "9876543210" },
-    "tcs": 4000,
-    "declarations": { "resident_in_india": true, "lrs": true, "tcs": true, "source_of_funds": true },
+    "tcs": 3976.40,
+    "declarations": { "resident_in_india": true, "lrs": true, "source_of_funds": true },
     "documents": [ { "type": "offer_letter", "ref": "<ref-from-step-3>" } ]
   }'
 ```

--- a/integration-guide/v3/web-integration/lrs-verification.mdx
+++ b/integration-guide/v3/web-integration/lrs-verification.mdx
@@ -35,7 +35,7 @@ A non-matching or rejected PAN returns `verified: false` with a `reason` (e.g. `
 
 ## Step 2: Quote the TCS
 
-Show the buyer a complete, tax-inclusive amount before they pay. The quote returns the TCS due and the all-in total to collect. For education from the buyer's own funds, TCS is **2% on the amount above ₹10,00,000** of the remitter's cumulative LRS this financial year — the first ₹10 lakh each year is TCS-free. The threshold is measured against the LRS usage EximPe can see, with no buyer self-declaration; the tax itself is charged on the settlement base (the remittance less EximPe's fee and the GST on it). `total_payable_inr` is **remittance + EximPe's fee + GST + TCS** — collect exactly that. Quoting reserves nothing, so you can re-quote freely.
+Show the buyer a complete, tax-inclusive amount before they pay. The quote returns the TCS due and the all-in total to collect. For education from the buyer's own funds, TCS is **2% on the amount above ₹10,00,000** of the remitter's cumulative LRS this financial year — the first ₹10 lakh each year is TCS-free. The threshold is measured against the LRS usage EximPe can see, with no buyer self-declaration; the tax itself is charged on the remittance amount, with EximPe's fee and the GST on it billed on top rather than deducted from it. `total_payable_inr` is **remittance + EximPe's fee + GST + TCS** — collect exactly that. Quoting reserves nothing, so you can re-quote freely.
 
 ```bash
 curl -X POST 'https://api-pacb-uat.eximpe.com/pg/lrs/quote/' \
@@ -85,7 +85,7 @@ curl -X POST 'https://api-pacb-uat.eximpe.com/pg/lrs/verify/' \
     "invoice": { "number": "INV-2025-0091", "date": "2025-07-01", "amount": 1200000 },
     "address": { "address1": "12 MG Road", "city": "Bengaluru", "state": "Karnataka", "pincode": "560001" },
     "contact": { "email": "john@example.com", "mobile": "9876543210" },
-    "tcs": 3976.40,
+    "tcs": 4000.00,
     "declarations": { "resident_in_india": true, "lrs": true, "source_of_funds": true },
     "documents": [ { "type": "offer_letter", "ref": "<ref-from-step-3>" } ]
   }'

--- a/integration-guide/v3/web-integration/lrs-verification.mdx
+++ b/integration-guide/v3/web-integration/lrs-verification.mdx
@@ -63,7 +63,7 @@ curl -X POST 'https://api-pacb-uat.eximpe.com/pg/lrs/documents/' \
   -F 'file=@offer_letter.pdf'
 ```
 
-Document `type` values depend on the purpose code — e.g. `offer_letter`, `fee_invoice`, `passport`, `relationship_declaration`, `student_id_or_visa`. See the [document matrix](/integration-guide/v3/web-integration/lrs-compliance#purpose-codes-and-documents) for which documents each purpose code requires.
+Document `type` values depend on the purpose code: `offer_letter`, `fee_invoice`, `passport`, `relationship_declaration`, `student_id_or_visa` (S0305) and `student_id` (S1107). See the [document matrix](/integration-guide/v3/web-integration/lrs-compliance#purpose-codes-and-documents) for which documents each purpose code requires.
 
 <Card title="📚 API Reference" href="/api-reference/v3/lrs/upload-document">
   **Upload LRS Document API** — accepted types and validation.

--- a/openapi/v3/openapi.json
+++ b/openapi/v3/openapi.json
@@ -2437,7 +2437,7 @@
     "/pg/lrs/quote/": {
       "post": {
         "summary": "Quote TCS and all-in total for a remittance",
-        "description": "Given a verified PAN and a proposed remittance amount (INR), returns the TCS due and the all-in total the buyer pays. TCS is nil up to Rs.10,00,000 of cumulative LRS this financial year and applies only to the slice above it (for education from the remitter's own funds the rate is 2%); education-loan-funded remittances are exempt. The Rs.10L threshold is measured on the remittance amount against EximPe's own LRS counter — there is no buyer self-declaration. The tax itself is charged on the settlement base (`amount` less EximPe's fee and the GST on it), and the all-in total is `amount` + fee + GST + TCS. This quotes against the LRS usage visible to us and reserves nothing. Requires a verified PAN and a `purpose_code` the sub-merchant is enabled for.\n\n**PSP callers must send `X-Merchant-ID`** naming the settling sub-merchant — LRS is always scoped to the settling entity, never the PSP.",
+        "description": "Given a verified PAN and a proposed remittance amount (INR), returns the TCS due and the all-in total the buyer pays. TCS is nil up to Rs.10,00,000 of cumulative LRS this financial year and applies only to the slice above it (for education from the remitter's own funds the rate is 2%); education-loan-funded remittances are exempt. The Rs.10L threshold is measured on the remittance amount against EximPe's own LRS counter — there is no buyer self-declaration. The tax itself is charged on `amount` — EximPe's fee and the GST on it are billed on top and do not reduce the taxable base — and the all-in total is `amount` + fee + GST + TCS. This quotes against the LRS usage visible to us and reserves nothing. Requires a verified PAN and a `purpose_code` the sub-merchant is enabled for.\n\n**PSP callers must send `X-Merchant-ID`** naming the settling sub-merchant — LRS is always scoped to the settling entity, never the PSP.",
         "tags": [
           "LRS"
         ],
@@ -2522,18 +2522,18 @@
                         },
                         "taxable_inr": {
                           "type": "string",
-                          "description": "Portion of the settlement base subject to TCS (INR). On the remittance that crosses Rs.10L this is the above-threshold slice with EximPe's fee netted off pro-rata, so it is slightly below the corresponding slice of `remittance_inr`.",
-                          "example": "198820.00"
+                          "description": "Portion of `remittance_inr` subject to TCS (INR). Zero below the Rs.10L threshold; the above-threshold slice on the remittance that crosses it; the whole of `remittance_inr` once the counter is past it. EximPe's fee is billed on top and never reduces it.",
+                          "example": "200000.00"
                         },
                         "tcs_inr": {
                           "type": "string",
                           "description": "TCS due on this remittance (INR).",
-                          "example": "3976.40"
+                          "example": "4000.00"
                         },
                         "total_payable_inr": {
                           "type": "string",
                           "description": "All-in total the buyer pays: remittance + EximPe's fee + GST on that fee + TCS. Collect exactly this — the fee and GST are not itemised in the response.",
-                          "example": "1211056.40"
+                          "example": "1211080.00"
                         },
                         "tcs_threshold_breached_before": {
                           "type": "boolean",
@@ -2556,9 +2556,9 @@
                     "financial_year": 2025,
                     "committed_inr": "0.00",
                     "remittance_inr": "1200000.00",
-                    "taxable_inr": "198820.00",
-                    "tcs_inr": "3976.40",
-                    "total_payable_inr": "1211056.40",
+                    "taxable_inr": "200000.00",
+                    "tcs_inr": "4000.00",
+                    "total_payable_inr": "1211080.00",
                     "tcs_threshold_breached_before": false,
                     "tcs_threshold_breached_after": true
                   }
@@ -2879,7 +2879,7 @@
                   "tcs": {
                     "type": "number",
                     "description": "TCS collected from the buyer, in INR rupees. Use the `tcs_inr` from the quote — we recompute it here and flag a mismatch.",
-                    "example": 3976.4
+                    "example": 4000
                   },
                   "declarations": {
                     "type": "object",
@@ -2977,7 +2977,7 @@
                   "email": "john@example.com",
                   "mobile": "9876543210"
                 },
-                "tcs": 3976.4,
+                "tcs": 4000,
                 "declarations": {
                   "resident_in_india": true,
                   "lrs": true,

--- a/openapi/v3/openapi.json
+++ b/openapi/v3/openapi.json
@@ -2505,6 +2505,11 @@
                     "data": {
                       "type": "object",
                       "properties": {
+                        "pan": {
+                          "type": "string",
+                          "description": "The PAN the quote was run for, upper-cased.",
+                          "example": "ABCDE1234F"
+                        },
                         "financial_year": {
                           "type": "string",
                           "description": "Financial year the quote applies to, rendered `YYYY-YY` (1 April - 31 March).",
@@ -2525,6 +2530,11 @@
                           "description": "Portion of `remittance_inr` subject to TCS (INR). Zero below the Rs.10L threshold; the above-threshold slice on the remittance that crosses it; the whole of `remittance_inr` once the counter is past it. EximPe's fee is billed on top and never reduces it.",
                           "example": "200000.00"
                         },
+                        "tcs_rate": {
+                          "type": "string",
+                          "description": "The TCS rate applied, formatted for display. Flat across every supported purpose code.",
+                          "example": "2%"
+                        },
                         "tcs_inr": {
                           "type": "string",
                           "description": "TCS due on this remittance (INR).",
@@ -2542,8 +2552,24 @@
                         },
                         "tcs_threshold_breached_after": {
                           "type": "boolean",
-                          "description": "Whether this remittance crosses the Rs.10L threshold.",
+                          "description": "Whether the counter is at or past Rs.10L once this remittance is counted. Also `true` when it was already past beforehand, and it flips at exactly Rs.10,00,000 — where `taxable_inr` is still `0.00`. Read `tcs_inr`, not this flag, to know whether tax is due.",
                           "example": true
+                        },
+                        "tcs_reason": {
+                          "type": "string",
+                          "enum": [
+                            "nil_below_threshold",
+                            "partial_above_threshold",
+                            "full_amount_taxable"
+                          ],
+                          "description": "Why this remittance was taxed as it was: cumulative LRS stays under Rs.10L; this remittance crosses the line and only the slice above it is taxed; or the counter was already past and the whole remittance is taxable.",
+                          "example": "partial_above_threshold"
+                        },
+                        "refusal_reason": {
+                          "type": "string",
+                          "nullable": true,
+                          "description": "Machine-readable code when we will not quote. `null` on a valid quote.",
+                          "example": null
                         }
                       }
                     }
@@ -2553,14 +2579,18 @@
                   "success": true,
                   "message": "LRS amount quoted",
                   "data": {
+                    "pan": "ABCDE1234F",
                     "financial_year": "2025-26",
                     "committed_inr": "0.00",
                     "remittance_inr": "1200000.00",
                     "taxable_inr": "200000.00",
+                    "tcs_rate": "2%",
                     "tcs_inr": "4000.00",
                     "total_payable_inr": "1211080.00",
                     "tcs_threshold_breached_before": false,
-                    "tcs_threshold_breached_after": true
+                    "tcs_threshold_breached_after": true,
+                    "tcs_reason": "partial_above_threshold",
+                    "refusal_reason": null
                   }
                 }
               }

--- a/openapi/v3/openapi.json
+++ b/openapi/v3/openapi.json
@@ -2506,9 +2506,9 @@
                       "type": "object",
                       "properties": {
                         "financial_year": {
-                          "type": "integer",
-                          "description": "Financial year the quote applies to (start year).",
-                          "example": 2025
+                          "type": "string",
+                          "description": "Financial year the quote applies to, rendered `YYYY-YY` (1 April - 31 March).",
+                          "example": "2025-26"
                         },
                         "committed_inr": {
                           "type": "string",
@@ -2553,7 +2553,7 @@
                   "success": true,
                   "message": "LRS amount quoted",
                   "data": {
-                    "financial_year": 2025,
+                    "financial_year": "2025-26",
                     "committed_inr": "0.00",
                     "remittance_inr": "1200000.00",
                     "taxable_inr": "200000.00",
@@ -2709,7 +2709,7 @@
     "/pg/lrs/verify/": {
       "post": {
         "summary": "Submit a payment's LRS verification details",
-        "description": "After a credit lands and the payment is created, submit the remitter, purpose, invoice, address, contact, declarations, supporting documents and the collected TCS. We run the checks (declarations, documents, sender-name match, TCS, money-match), post the payment to the buyer's LRS counter and advance it to **Under Review** — or leave it in **Action Required** (with a `missing` list) or **On Hold** (sender is not the PAN holder). The money-match requires the credit to cover the remitted principal, EximPe's fee, the GST on that fee and the TCS — anything short comes back as `outstanding`. `primary_person` is required when the remitter's `relation` is not `SELF`.\n\n**PSP callers must send `X-Merchant-ID`** naming the settling sub-merchant.",
+        "description": "After a credit lands and the payment is created, submit the remitter, purpose, invoice, address, contact, declarations, supporting documents and the collected TCS. We run the checks (declarations, documents, sender-name match, TCS, money-match), post the payment to the buyer's LRS counter and advance it to **Under Review** — or leave it in **Action Required**, either with a `missing` list or because the credit's sender is not the declared PAN holder (`reason: SENDER_NAME_MISMATCH`). LRS has no On Hold state: every outcome that does not advance stays in Action Required and is fixed by re-submitting. The money-match requires the credit to cover the remitted principal, EximPe's fee, the GST on that fee and the TCS — anything short comes back as `outstanding`. `primary_person` is required when the remitter's `relation` is not `SELF`.\n\n**PSP callers must send `X-Merchant-ID`** naming the settling sub-merchant.",
         "tags": [
           "LRS"
         ],
@@ -2734,6 +2734,7 @@
                   "invoice",
                   "address",
                   "contact",
+                  "principal",
                   "tcs",
                   "declarations",
                   "documents"
@@ -2827,6 +2828,7 @@
                       },
                       "amount": {
                         "type": "number",
+                        "description": "Invoice total in INR rupees — metadata for the settlement file. It may be met across several payments, so it does not gate the money-match; `principal` does.",
                         "example": 1200000
                       }
                     }
@@ -2875,6 +2877,11 @@
                         "example": "9876543210"
                       }
                     }
+                  },
+                  "principal": {
+                    "type": "number",
+                    "description": "This payment's remitted principal, in INR rupees — the money that goes abroad. The money-match target is `principal` + EximPe's fee + GST on that fee + TCS; this is also what posts to the buyer's Rs.10L LRS counter and what TCS is charged on. Distinct from `invoice.amount`: one invoice may be met across several payments, each with its own principal.",
+                    "example": 1200000
                   },
                   "tcs": {
                     "type": "number",
@@ -2977,6 +2984,7 @@
                   "email": "john@example.com",
                   "mobile": "9876543210"
                 },
+                "principal": 1200000,
                 "tcs": 4000,
                 "declarations": {
                   "resident_in_india": true,
@@ -3024,10 +3032,9 @@
                           "type": "string",
                           "enum": [
                             "under_review",
-                            "action_required",
-                            "on_hold"
+                            "action_required"
                           ],
-                          "description": "Resulting payment state.",
+                          "description": "Resulting payment state. There is no On Hold outcome on LRS — anything that does not advance stays in `action_required`.",
                           "example": "under_review"
                         },
                         "tcs_check": {
@@ -3055,7 +3062,7 @@
                         "reason": {
                           "type": "string",
                           "nullable": true,
-                          "description": "Machine reason when not advanced (e.g. PURPOSE_CODE_NOT_ALLOWED, PAN_NOT_VERIFIED).",
+                          "description": "Machine reason when not advanced: `SENDER_NAME_MISMATCH`, `PURPOSE_CODE_NOT_ALLOWED`, `PURPOSE_CODE_NOT_IN_REGISTRY` or `PAN_NOT_VERIFIED`. Null when the payment advanced, and null on an Action Required caused only by gaps in `missing`.",
                           "example": null
                         }
                       }
@@ -3096,18 +3103,18 @@
                       }
                     }
                   },
-                  "on_hold": {
-                    "summary": "On Hold — sender is not the PAN holder",
+                  "sender_mismatch": {
+                    "summary": "Action Required — sender is not the PAN holder",
                     "value": {
                       "success": true,
                       "message": "Verification details processed",
                       "data": {
                         "payment_id": "PAY_1a2b3c4d5e",
-                        "status": "on_hold",
-                        "tcs_check": "n/a",
+                        "status": "action_required",
+                        "tcs_check": "match",
                         "missing": [],
                         "outstanding": "0.00",
-                        "reason": "SENDER_NOT_PAN_HOLDER"
+                        "reason": "SENDER_NAME_MISMATCH"
                       }
                     }
                   }

--- a/openapi/v3/openapi.json
+++ b/openapi/v3/openapi.json
@@ -2437,7 +2437,7 @@
     "/pg/lrs/quote/": {
       "post": {
         "summary": "Quote TCS and all-in total for a remittance",
-        "description": "Given a verified PAN and a proposed remittance amount (INR), returns the TCS due and the all-in total the buyer pays. TCS is nil up to Rs.10,00,000 of cumulative LRS this financial year and applies only to the slice above it (for education from the remitter's own funds the rate is 2%); education-loan-funded remittances are exempt. This quotes against the LRS usage visible to us and reserves nothing. Requires a verified PAN and a `purpose_code` the sub-merchant is enabled for.\n\n**PSP callers must send `X-Merchant-ID`** naming the settling sub-merchant — LRS is always scoped to the settling entity, never the PSP.",
+        "description": "Given a verified PAN and a proposed remittance amount (INR), returns the TCS due and the all-in total the buyer pays. TCS is nil up to Rs.10,00,000 of cumulative LRS this financial year and applies only to the slice above it (for education from the remitter's own funds the rate is 2%); education-loan-funded remittances are exempt. The Rs.10L threshold is measured on the remittance amount against EximPe's own LRS counter — there is no buyer self-declaration. The tax itself is charged on the settlement base (`amount` less EximPe's fee and the GST on it), and the all-in total is `amount` + fee + GST + TCS. This quotes against the LRS usage visible to us and reserves nothing. Requires a verified PAN and a `purpose_code` the sub-merchant is enabled for.\n\n**PSP callers must send `X-Merchant-ID`** naming the settling sub-merchant — LRS is always scoped to the settling entity, never the PSP.",
         "tags": [
           "LRS"
         ],
@@ -2458,8 +2458,7 @@
                 "required": [
                   "pan",
                   "amount",
-                  "purpose_code",
-                  "tcs_threshold_breached"
+                  "purpose_code"
                 ],
                 "properties": {
                   "pan": {
@@ -2476,19 +2475,13 @@
                     "type": "string",
                     "description": "FEMA purpose code; must be one the sub-merchant is enabled for.",
                     "example": "S0305"
-                  },
-                  "tcs_threshold_breached": {
-                    "type": "boolean",
-                    "description": "Buyer's self-declaration that they have already crossed Rs.10L of LRS this FY elsewhere. When true, the full remittance is taxed.",
-                    "example": false
                   }
                 }
               },
               "example": {
                 "pan": "ABCDE1234F",
                 "amount": 1200000,
-                "purpose_code": "S0305",
-                "tcs_threshold_breached": false
+                "purpose_code": "S0305"
               }
             }
           }
@@ -2529,22 +2522,22 @@
                         },
                         "taxable_inr": {
                           "type": "string",
-                          "description": "Portion of the remittance subject to TCS (INR).",
-                          "example": "200000.00"
+                          "description": "Portion of the settlement base subject to TCS (INR). On the remittance that crosses Rs.10L this is the above-threshold slice with EximPe's fee netted off pro-rata, so it is slightly below the corresponding slice of `remittance_inr`.",
+                          "example": "198820.00"
                         },
                         "tcs_inr": {
                           "type": "string",
                           "description": "TCS due on this remittance (INR).",
-                          "example": "4000.00"
+                          "example": "3976.40"
                         },
                         "total_payable_inr": {
                           "type": "string",
-                          "description": "All-in total the buyer pays (remittance + TCS).",
-                          "example": "1204000.00"
+                          "description": "All-in total the buyer pays: remittance + EximPe's fee + GST on that fee + TCS. Collect exactly this — the fee and GST are not itemised in the response.",
+                          "example": "1211056.40"
                         },
                         "tcs_threshold_breached_before": {
                           "type": "boolean",
-                          "description": "Whether the Rs.10L threshold was already crossed before this remittance.",
+                          "description": "Whether EximPe's LRS counter had already crossed Rs.10L before this remittance.",
                           "example": false
                         },
                         "tcs_threshold_breached_after": {
@@ -2563,9 +2556,9 @@
                     "financial_year": 2025,
                     "committed_inr": "0.00",
                     "remittance_inr": "1200000.00",
-                    "taxable_inr": "200000.00",
-                    "tcs_inr": "4000.00",
-                    "total_payable_inr": "1204000.00",
+                    "taxable_inr": "198820.00",
+                    "tcs_inr": "3976.40",
+                    "total_payable_inr": "1211056.40",
                     "tcs_threshold_breached_before": false,
                     "tcs_threshold_breached_after": true
                   }
@@ -2716,7 +2709,7 @@
     "/pg/lrs/verify/": {
       "post": {
         "summary": "Submit a payment's LRS verification details",
-        "description": "After a credit lands and the payment is created, submit the remitter, purpose, invoice, address, contact, declarations, supporting documents and the collected TCS. We run the checks (declarations, documents, sender-name match, TCS, money-match), post the payment to the buyer's LRS counter and advance it to **Under Review** — or leave it in **Action Required** (with a `missing` list) or **On Hold** (sender is not the PAN holder). `primary_person` is required when the remitter's `relation` is not `SELF`.\n\n**PSP callers must send `X-Merchant-ID`** naming the settling sub-merchant.",
+        "description": "After a credit lands and the payment is created, submit the remitter, purpose, invoice, address, contact, declarations, supporting documents and the collected TCS. We run the checks (declarations, documents, sender-name match, TCS, money-match), post the payment to the buyer's LRS counter and advance it to **Under Review** — or leave it in **Action Required** (with a `missing` list) or **On Hold** (sender is not the PAN holder). The money-match requires the credit to cover the remitted principal, EximPe's fee, the GST on that fee and the TCS — anything short comes back as `outstanding`. `primary_person` is required when the remitter's `relation` is not `SELF`.\n\n**PSP callers must send `X-Merchant-ID`** naming the settling sub-merchant.",
         "tags": [
           "LRS"
         ],
@@ -2755,12 +2748,6 @@
                     "type": "string",
                     "description": "FEMA purpose code for the remittance.",
                     "example": "S0305"
-                  },
-                  "tcs_threshold_breached": {
-                    "type": "boolean",
-                    "default": false,
-                    "description": "Buyer's self-declaration that Rs.10L LRS was already crossed this FY.",
-                    "example": false
                   },
                   "remitter": {
                     "type": "object",
@@ -2891,28 +2878,23 @@
                   },
                   "tcs": {
                     "type": "number",
-                    "description": "TCS collected from the buyer, in INR rupees.",
-                    "example": 4000
+                    "description": "TCS collected from the buyer, in INR rupees. Use the `tcs_inr` from the quote — we recompute it here and flag a mismatch.",
+                    "example": 3976.4
                   },
                   "declarations": {
                     "type": "object",
                     "required": [
                       "resident_in_india",
                       "lrs",
-                      "tcs",
                       "source_of_funds"
                     ],
-                    "description": "All four must be true for the payment to clear checks; otherwise it stays in Action Required.",
+                    "description": "All three must be true for the payment to clear checks; otherwise it stays in Action Required.",
                     "properties": {
                       "resident_in_india": {
                         "type": "boolean",
                         "example": true
                       },
                       "lrs": {
-                        "type": "boolean",
-                        "example": true
-                      },
-                      "tcs": {
                         "type": "boolean",
                         "example": true
                       },
@@ -2974,7 +2956,6 @@
               "example": {
                 "payment_id": "PAY_1a2b3c4d5e",
                 "purpose_code": "S0305",
-                "tcs_threshold_breached": false,
                 "remitter": {
                   "pan": "ABCDE1234F",
                   "name": "John Doe",
@@ -2996,11 +2977,10 @@
                   "email": "john@example.com",
                   "mobile": "9876543210"
                 },
-                "tcs": 4000,
+                "tcs": 3976.4,
                 "declarations": {
                   "resident_in_india": true,
                   "lrs": true,
-                  "tcs": true,
                   "source_of_funds": true
                 },
                 "documents": [
@@ -3069,7 +3049,7 @@
                         },
                         "outstanding": {
                           "type": "string",
-                          "description": "Shortfall still owed (INR), if any.",
+                          "description": "Shortfall still owed (INR), if any — principal + EximPe's fee + GST on that fee + TCS, less what the credit brought in.",
                           "example": "0.00"
                         },
                         "reason": {


### PR DESCRIPTION
## Summary

This PR brings the v3 LRS docs in line with the shipped backend. Two groups of change: what the backend actually altered (#1825 as amended by #1834), and the spec/guide errors found while verifying this diff against the code on `production`.

### What the backend changed

1. **`tcs_threshold_breached` is gone** from both the quote and the submit payloads — the ₹10 lakh threshold now comes from EximPe's own LRS counter, never a buyer self-declaration.
2. **`declarations.tcs` is gone** — three declarations remain, not four.
3. **The all-in total grew.** TCS is charged on the remittance amount and the buyer pays `principal + MDR + GST + TCS`. The money-match on submit expects the same figure.

Tracks [eximpe_pacb_backend#1825](https://github.com/EximPe/eximpe_pacb_backend/pull/1825) as amended by [#1834](https://github.com/EximPe/eximpe_pacb_backend/pull/1834). **#1834 reversed the TCS base** that #1825 introduced: the tax is levied on the principal, not on `principal − MDR − GST`, because EximPe's fee and the GST on it are billed on top of the remittance rather than taken out of it. The pro-rata fee netting on the crossing payment went with it.

### What was already wrong

Verified field by field against `origin/production` (tip `e0f7f48e`, migrations `0134`/`0135` present, so both backend PRs are live). Three defects that would break a partner on their first call, all pre-existing:

4. **`principal` was undocumented on submit.** The backend has required it since the endpoint shipped (`SubmitVerificationDetailsSerializer`) and the money-match is built on it, yet it appeared in neither the spec nor the guide — both documented payloads would 400.
5. **`on_hold` is not an LRS outcome.** `submit_verification_details` never returns it: LRS has no On Hold state, and a sender-name mismatch stays in Action Required with `reason: SENDER_NAME_MISMATCH`. The spec documented an `on_hold` status, an `on_hold` example, and an invented reason `SENDER_NOT_PAN_HOLDER`.
6. **`financial_year` is a string, not an integer.** The view renders it through `_fy_display` as `YYYY-YY` (`"2025-26"`); the spec typed it `integer` with example `2025`.
7. **The quote response was four fields short.** `pan`, `tcs_rate`, `tcs_reason` and `refusal_reason` are all returned by `LrsViewSet.quote` and none were documented; `tcs_threshold_breached_after` was misdescribed.

Docs-only. Nothing partner-invisible is documented (MDR resolution, the stored `mdr_cents` / `gst_on_mdr_cents` / `our_tcs_cents`, migrations `0134`/`0135`, the ICICI settlement-file columns).

## Changes

### 1. Request fields removed

| File | Change |
|---|---|
| `openapi/v3/openapi.json` — `POST /pg/lrs/quote/` | `tcs_threshold_breached` dropped from `required`, from `properties`, and from the example |
| `openapi/v3/openapi.json` — `POST /pg/lrs/verify/` | `tcs_threshold_breached` dropped; `declarations.tcs` dropped from `required`, `properties` and the example; "All four must be true" → "All three" |
| `integration-guide/v3/web-integration/lrs-verification.mdx` | Both curl examples updated to match |

### 2. What the buyer pays

| File | Change |
|---|---|
| `openapi/v3/openapi.json` — quote | Operation description states the tax is charged on `amount` with the fee billed on top; `taxable_inr`, `tcs_inr`, `total_payable_inr` descriptions and the response example re-derived; `tcs_threshold_breached_before` reworded as counter-driven |
| `openapi/v3/openapi.json` — verify | Operation description and `outstanding` say the credit must cover principal + fee + GST + TCS; `tcs` example `4000` |
| `integration-guide/v3/web-integration/lrs-verification.mdx` | Step 2 and Step 4 prose |
| `integration-guide/v3/web-integration/lrs-compliance.mdx` | TCS section rewritten: counter-driven threshold, the tax charged on the principal with the fee on top, the above-threshold slice taxed in full, and the all-in total |
| `integration-guide/v3/getting-started/faqs.mdx` | "How is TCS calculated?" and "Do I have to call the quote API?" |

### 3. Declarations

| File | Change |
|---|---|
| `integration-guide/v3/web-integration/lrs-compliance.mdx` | "Two declarations" → one buyer declaration mapping to three API fields; Declaration 2 replaced by a note saying the ₹10 lakh question is no longer collected and that stale requests sending either field are accepted and ignored, not rejected |
| `integration-guide/v3/getting-started/faqs.mdx` | "What declarations does the buyer affirm?" |

### 4. `principal` documented on submit

| File | Change |
|---|---|
| `openapi/v3/openapi.json` — verify | `principal` added to `required` (between `contact` and `tcs`), added to `properties` with its relationship to the money-match, the LRS counter and the TCS base, and added to the request example |
| `openapi/v3/openapi.json` — verify | `invoice.amount` gains a description: settlement-file metadata, may be met across several payments, does **not** gate the money-match |
| `integration-guide/v3/web-integration/lrs-verification.mdx` | Added to the Step 4 curl, plus a paragraph distinguishing `principal` from `invoice.amount` |
| `integration-guide/v3/web-integration/collection-overview.mdx` | Added to the submit step's field list |
| `integration-guide/v3/web-integration/lrs-verification.mdx` | Step 3's document-type list completed — `student_id` (S1107's enrolment proof) was the one type of the six missing |

### 5. `on_hold` removed

| File | Change |
|---|---|
| `openapi/v3/openapi.json` — verify | `status` enum → `["under_review", "action_required"]`; operation description and the field description both state that LRS has no On Hold state; the `on_hold` response example becomes `sender_mismatch` (`action_required` + `SENDER_NAME_MISMATCH`); `reason` now enumerates the four real values (`SENDER_NAME_MISMATCH`, `PURPOSE_CODE_NOT_ALLOWED`, `PURPOSE_CODE_NOT_IN_REGISTRY`, `PAN_NOT_VERIFIED`) |
| `integration-guide/v3/web-integration/lrs-verification.mdx` | `on_hold` row dropped from the status table; replaced by the sender-mismatch note |
| `integration-guide/v3/getting-started/faqs.mdx` | "a mismatch puts the payment **On Hold**" → stays in Action Required with `SENDER_NAME_MISMATCH` |
| `integration-guide/v3/web-integration/collection-overview.mdx` | "goes **On Hold**" dropped from the LRS flow steps |

### 6. Quote response completed

| File | Change |
|---|---|
| `openapi/v3/openapi.json` — quote | `financial_year` retyped `"integer"` / `2025` → `"string"` / `"2025-26"`, description updated to `YYYY-YY` |
| `openapi/v3/openapi.json` — quote | `pan`, `tcs_rate` (`"2%"`), `tcs_reason` (enum'd `nil_below_threshold` / `partial_above_threshold` / `full_amount_taxable`) and `refusal_reason` (nullable) added — the response now documents all twelve fields the view emits, in the order it emits them |
| `openapi/v3/openapi.json` — quote | `tcs_threshold_breached_after` reworded: it is also `true` when the counter was already past Rs.10L, and it flips at exactly Rs.10,00,000 where `taxable_inr` is still `0.00`. Branch on `tcs_inr`, not the flag |
| `openapi/v3/openapi.json` — quote | Response example extended with all five |

## Worked example (used in the quote spec)

₹12,00,000 remittance, nothing committed this FY, 0.5% MDR + 18% GST:

| | |
|---|---|
| MDR | ₹6,000 |
| GST on MDR | ₹1,080 |
| Above-threshold slice of the principal | ₹2,00,000 |
| `taxable_inr` (the slice, taxed in full) | ₹2,00,000 |
| `tcs_inr` @ 2% | ₹4,000.00 |
| `total_payable_inr` | ₹12,11,080.00 |

## ClickUp
- https://app.clickup.com/t/86d40dcb8

## Test plan
- [x] `openapi/v3/openapi.json` parses
- [x] No "settlement base" or "pro-rata" strings remain in `integration-guide/v3` or the spec
- [x] No `on_hold` / `On Hold` / `SENDER_NOT_PAN_HOLDER` strings remain in `openapi/v3`, `integration-guide/v3` or `api-reference/v3`
- [x] `total_payable_inr` reconciles: `1200000 + 6000 + 1080 + 4000 = 1211080`
- [x] Every documented request field checked against the serializers on `origin/production`; the quote response checked field-for-field against `partner_api/views/lrs.py` (all twelve now present, none extra)
- [x] `npx mint@latest broken-links` — no new broken links (run on the first commit; the later commits change prose, numbers and JSON structure only, adding and removing no links)
- [ ] Visual review in a browser — **not done**. Build and HTTP status only, and the numbers were derived by hand from the backend PRs, not observed from a live response

## Please check

- **Deploy order — now satisfied.** `production` (`e0f7f48e`), `uat` and `main` all carry #1825 and #1834. `principal` has been required all along, so documenting it does not depend on either PR. Only an environment behind both would diverge from this page.
- **The fee is not itemised in the quote response.** `total_payable_inr` includes MDR and GST, but nothing in the response breaks them out, so a partner cannot reconcile the total or show the buyer a line-item split. Worth deciding whether the response should expose them before partners build against it.
- **MDR of 0.5% in the worked example** is illustrative, taken from the backend PRs' own example. If a canonical partner rate should be used instead, say which.

## Known gaps, deliberately not in this PR

Left for a follow-up so this diff stays on the TCS change and the LRS API surface itself:

- **Undocumented submit behaviour**: submit is only accepted from Action Required (else 400 `PAYMENT_NOT_SUBMITTABLE`); `purpose_code` and `principal` are locked on re-submit; an unknown/foreign document `ref` or a type disagreeing with the upload is a hard 400 rather than an Action-Required gap; the `missing[]` values are never enumerated; `tcs` must match our recompute exactly; overpayment does not block; `linked_payment_id` must be a payment of the same buyer/VA.
- **Undocumented quote behaviour**: 400 also when the purpose code is not in the registry, not just outside the merchant allowlist; a merchant with no `vba_transfer` MDR rate is charged no fee, so `total_payable_inr` is principal + TCS.
- **LRS webhooks** — the largest gap. `verification-needed.mdx` documents only the goods-flow payload (`order_id`, `verification_status`, `action_required_fields`); LRS reuses the same event type with a different `data` block (`status`, `va_id`, `sub_merchant_id`, `amount`, `currency`, `payer_remarks`, `missing`, `outstanding`, `reason`). `PAYMENT_UNDER_REVIEW`, emitted on a successful submit, has no page at all.

Two further discrepancies were found and knowingly left alone:

- **The USD 250,000 cap.** `lrs-compliance.mdx` and `faqs.mdx` say EximPe refuses any remittance that would breach it. The code does not: `LRS_CAP_EXCEEDED` is defined but never raised, `refusal_reason` is hardcoded `null`, and `record_committed` posts `usd_cents=0`, so the USD counter never advances at submit. The docs are ahead of the code here.
- **"Education-loan-funded remittances are exempt"** in the quote description. Both registered purpose codes (`S0305`, `S1107`) are `tcs_applicable=True`, and both guides already say loan-funded remittances are out of scope.

Refs: CU-86d40dcb8
