### PR TITLE
docs(v3): add the sandbox simulator settlement and refund-status endpoints

### DIFF
--- a/api-reference/v3/refunds/simulate-status.mdx
+++ b/api-reference/v3/refunds/simulate-status.mdx
@@ -1,0 +1,112 @@
+---
+title: 'Set Refund Status (Sandbox)'
+description: 'Force a refund to any status on demand and fire the matching webhook, so one refund can exercise every branch of your handler.'
+openapi: 'POST /pg/refunds/{refund_id}/simulate-status/'
+---
+
+<Warning>
+  **Sandbox only.** This endpoint returns `400` in production. It operates only on refunds created through the **Simulator** payment gateway — a refund on a real gateway is rejected.
+</Warning>
+
+## Overview
+
+A real refund walks `INITIATED → REFUNDED` or `INITIATED → FAILED`, driven by the bank on its own timetable. Statuses like `REVERSED` or `BANK_REJECTED_REFUND` are rare enough that you may never see one before it happens in production.
+
+This endpoint forces a refund straight to any status and fires the same webhook a real change would, so you can exercise every branch of your handler deliberately.
+
+## Statuses
+
+| Value | Default message | Meaning |
+|---|---|---|
+| `INITIATED` | `Refund initiated` | Accepted, not yet processing |
+| `PROCESSING` | `Refund processing` | In flight at the bank |
+| `REFUNDED` | `Simulated refund settled` | Successfully refunded |
+| `FAILED` | `Simulated refund failed` | Refund failed |
+| `REVERSED` | `Refund reversed` | Reversed after being sent |
+| `ON_HOLD` | `Refund on hold` | Held for review |
+| `BANK_REJECTED_REFUND` | `Refund rejected by bank` | Rejected by the beneficiary bank |
+
+Setting `REFUNDED` also stamps `refunded_at` with the current time, if it is not already set.
+
+<Note>
+  **Terminal statuses are reversible here.** You may move a refund out of `REFUNDED` or `FAILED` and back again. This is deliberate — it lets one refund cover the whole matrix instead of needing a fresh one per branch.
+</Note>
+
+## Which webhook fires
+
+| Target status | Webhook |
+|---|---|
+| `REFUNDED` | [`PAYMENT_REFUNDED`](/api-reference/v3/webhooks/payment-refunded) |
+| `FAILED` | [`REFUND_FAILED`](/api-reference/v3/webhooks/refund-failed) |
+| `PROCESSING` | [`REFUND_STATUS_UPDATE`](/api-reference/v3/webhooks/refund-status-update) |
+| `REVERSED` | [`REFUND_STATUS_UPDATE`](/api-reference/v3/webhooks/refund-status-update) |
+| `ON_HOLD` | [`REFUND_STATUS_UPDATE`](/api-reference/v3/webhooks/refund-status-update) |
+| `BANK_REJECTED_REFUND` | [`REFUND_STATUS_UPDATE`](/api-reference/v3/webhooks/refund-status-update) |
+| `INITIATED` | **None** — it is the starting state, not a transition worth notifying |
+
+<Warning>
+  **Webhooks fire only on a genuine transition.** Setting a refund to the status it already holds returns `200` and sends nothing. To re-trigger an event, move the refund to a different status first.
+</Warning>
+
+Your `status_message` is carried into the webhook, so you can assert on it end to end.
+
+## Case asymmetry
+
+You send `"status": "FAILED"` and receive `"refund_status": "failed"`.
+
+Requests take **uppercase**; responses return **lowercase**. Sending `"refunded"` is rejected as an invalid choice — the most common cause of a `400` on this endpoint. Uppercase the response value before comparing it to what you sent.
+
+## Exercising every branch
+
+Walk one refund through each status, checking your handler at each step:
+
+```
+INITIATED → PROCESSING → ON_HOLD → BANK_REJECTED_REFUND → FAILED → REFUNDED
+```
+
+Each transition fires the corresponding event from the table above.
+
+### Testing a failed refund
+
+```bash
+curl -X POST "https://<your-sandbox-host>/pg/refunds/RF7019490071/simulate-status/" \
+  -H "X-Client-ID: <client-id>" \
+  -H "X-Client-Secret: <client-secret>" \
+  -H "Content-Type: application/json" \
+  -d '{
+        "status": "FAILED",
+        "status_message": "Beneficiary account closed"
+      }'
+```
+
+Your endpoint receives `REFUND_FAILED` carrying your custom message.
+
+## Errors
+
+`400` responses use `error.code` = `ERR_REFUND_002`:
+
+| `details` | Cause |
+|---|---|
+| `status: "…" is not a valid choice.` | Unknown status, or lowercase |
+| `status: This field is required.` | `status` omitted |
+| `refund_uid: RF… is not on the simulator gateway` | Refund created on a real gateway |
+| `error: Refund status simulation is not available in production` | Called in production |
+
+<Warning>
+  **`404` does not use the standard envelope.** A refund that does not exist — or belongs to another merchant — returns a bare `{"detail": "..."}` rather than the `success`/`error` shape. Handle that separately.
+
+  Note this is a `404`, not a `403`: refunds are scoped to your account and its sub-merchants, and someone else's refund is simply not found.
+</Warning>
+
+A `500` on this endpoint uses `ERR_SERVICE_ERROR_000`, unlike its `400`s.
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="Mark as Settled" icon="money-check-dollar" href="/api-reference/v3/settlement/mark-settled">
+    Settle payments on demand, refunds and chargebacks included.
+  </Card>
+  <Card title="Create Refund" icon="rotate-left" href="/api-reference/v3/refunds/create">
+    Create the refund you are going to drive.
+  </Card>
+</CardGroup>

--- a/api-reference/v3/settlement/mark-settled.mdx
+++ b/api-reference/v3/settlement/mark-settled.mdx
@@ -1,0 +1,153 @@
+---
+title: 'Mark as Settled (Sandbox)'
+description: 'Batch captured payments — plus optional refunds and chargebacks — into one settlement and fire PAYMENT_SETTLED, without waiting for real money movement.'
+openapi: 'POST /pg/settlements/mark-settled/'
+---
+
+<Warning>
+  **Sandbox only.** This endpoint returns `400` in production. It operates only on transactions created through the **Simulator** payment gateway — a real Cashfree or ICICI transaction is rejected.
+
+  Your account must be assigned the Simulator gateway in sandbox. Contact your EximPe integration manager if it isn't.
+</Warning>
+
+## Overview
+
+Settlement is the one part of the payment lifecycle you cannot trigger yourself: it happens when money actually moves, on the bank's schedule. That makes settlement webhook handlers and reconciliation logic awkward to test.
+
+This endpoint settles payments on demand. It applies a simulated fee schedule, creates a real settlement record, and fires [`PAYMENT_SETTLED`](/api-reference/v3/webhooks/payment-settled) exactly as production would.
+
+## How the amounts are calculated
+
+Per payment, against the **order amount**:
+
+| Component | Rule |
+|---|---|
+| Platform fee | 5% of the order amount |
+| GST | 18% of the platform fee |
+| Net | order amount − platform fee − GST |
+| Forex rate | Fixed at `96` |
+
+The settlement totals are the sums across the batch:
+
+- `settlement_amount` = Σ payment net − Σ refund amounts − Σ chargeback amounts
+- `settlement_charges` = Σ platform fees
+- `settlement_gst` = Σ GST
+
+Refunds and chargebacks carry **no fee of their own**. They debit the total at their full amount, mirroring the real settlement pipeline.
+
+<Accordion title="Worked example — ₹1,000 payment, ₹100 refund, ₹50 chargeback">
+```
+Payment order amount        ₹1,000.00
+  platform fee (5%)         −  ₹50.00
+  GST (18% of fee)          −   ₹9.00
+  net                       =  ₹941.00
+
+Refund                      − ₹100.00
+Chargeback                  −  ₹50.00
+                            ──────────
+settlement_amount           =  ₹791.00
+settlement_charges          =   ₹50.00
+settlement_gst              =    ₹9.00
+```
+</Accordion>
+
+<Note>
+  These are simulator figures, not your contracted rates. Use them to check that your reconciliation *arithmetic* holds, not to predict production settlement amounts.
+</Note>
+
+## Side effects
+
+Each payment in the batch gets `settlement_status` = `SETTLED` and its per-payment breakdown populated — fee, tax, net, forex rate, settlement currency — in the same shape a real settlement produces.
+
+<Tip>
+  The batch is atomic. If any payment fails validation **nothing** is written, so a partially-settled batch is not a state you can reach.
+</Tip>
+
+## What each payment must satisfy
+
+A payment is rejected unless it is:
+
+1. **Yours** — belonging to your merchant account or one of your sub-merchants
+2. **On the Simulator gateway**
+3. **`CAPTURED`**
+4. **Not already settled** — a payment belongs to exactly one settlement
+
+<Note>
+  A UID owned by a different merchant is indistinguishable from one that does not exist. Both simply fail to resolve.
+</Note>
+
+## Reading validation errors
+
+Unresolvable UIDs come back grouped by category, with the **first** failure in each. Empty categories return `[]`.
+
+```json
+{
+  "success": false,
+  "error": {
+    "code": "ERR_SERVICE_ERROR_000",
+    "message": "Payment gateway error",
+    "details": {
+      "payment_uids": "PR0000000000",
+      "refund_uids": [],
+      "chargeback_uids": []
+    }
+  }
+}
+```
+
+Because only the first failure per category is reported, fix them one at a time or pre-validate your list.
+
+State problems name the offending UID directly:
+
+| `details.payment_uids` | Meaning |
+|---|---|
+| `PR… is not on the simulator gateway` | Created on a real gateway |
+| `PR… is not captured` | Payment has not succeeded |
+| `PR… is already settled` | Belongs to another settlement — create a fresh payment |
+
+## Testing your settlement handler
+
+<Steps>
+  <Step title="Capture a payment">
+    Create an order and complete it on the Simulator gateway so the payment reaches `CAPTURED`.
+  </Step>
+  <Step title="Settle it">
+    `POST /pg/settlements/mark-settled/` with that payment's UID.
+  </Step>
+  <Step title="Receive the webhook">
+    Your endpoint gets [`PAYMENT_SETTLED`](/api-reference/v3/webhooks/payment-settled) carrying the new settlement.
+  </Step>
+  <Step title="Reconcile">
+    `GET /pg/settlements/{settlement_id}/` and check your records agree.
+  </Step>
+</Steps>
+
+To exercise a **net** settlement, create a refund and a chargeback against the payment first, then pass all three UIDs in one call and confirm `settlement_amount` equals the payment net minus both.
+
+## Gotchas
+
+<AccordionGroup>
+  <Accordion title="Amounts are strings in rupees, not integer paise">
+    `"941.00"`, not `94100`. Parse as decimal — never as a float, for money.
+  </Accordion>
+  <Accordion title="A payment can be settled only once">
+    Re-settling returns `is already settled`. Create a fresh payment for each settlement test.
+  </Accordion>
+  <Accordion title="settlement_charges and settlement_gst cover payments only">
+    Refunds and chargebacks carry no fee. They only reduce `settlement_amount`.
+  </Accordion>
+  <Accordion title="It is a POST, despite reading like a bulk update">
+    Both simulator endpoints are `POST`.
+  </Accordion>
+</AccordionGroup>
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="Set Refund Status" icon="rotate-left" href="/api-reference/v3/refunds/simulate-status">
+    Drive a refund to any status on demand.
+  </Card>
+  <Card title="PAYMENT_SETTLED" icon="webhook" href="/api-reference/v3/webhooks/payment-settled">
+    The event this endpoint fires.
+  </Card>
+</CardGroup>

--- a/docs.json
+++ b/docs.json
@@ -403,7 +403,8 @@
                 "pages": [
                   "api-reference/v3/settlement/list",
                   "api-reference/v3/settlement/get",
-                  "api-reference/v3/settlement/recon"
+                  "api-reference/v3/settlement/recon",
+                  "api-reference/v3/settlement/mark-settled"
                 ]
               },
               {
@@ -411,7 +412,8 @@
                 "pages": [
                   "api-reference/v3/refunds/create",
                   "api-reference/v3/refunds/list",
-                  "api-reference/v3/refunds/get"
+                  "api-reference/v3/refunds/get",
+                  "api-reference/v3/refunds/simulate-status"
                 ]
               },
               {

--- a/openapi/v3/openapi.json
+++ b/openapi/v3/openapi.json
@@ -3158,6 +3158,397 @@
         },
         "operationId": "v3_post_pg_lrs_verify_"
       }
+    },
+    "/pg/settlements/mark-settled/": {
+      "post": {
+        "summary": "Mark payments as settled (sandbox)",
+        "description": "Batches one or more captured payments — plus, optionally, refunds and chargebacks — into a single new settlement, applies a simulated fee schedule, and fires the [`PAYMENT_SETTLED`](/api-reference/v3/webhooks/payment-settled) webhook. Use it to exercise your settlement handler and reconciliation without waiting for real money movement.\n\n**Sandbox only.** This endpoint returns `400` in production, and operates only on transactions created through the **Simulator** payment gateway — a real Cashfree or ICICI transaction is rejected.\n\nThe batch is atomic: if any payment fails validation nothing is written, so a partially-settled batch is not a state you can reach.\n\n**PSP callers must send `X-Merchant-ID`.**",
+        "tags": [
+          "Settlement"
+        ],
+        "security": [
+          {
+            "clientAuth": [],
+            "clientSecretAuth": [],
+            "merchantAuth": [],
+            "apiVersionHeader": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "payment_uids"
+                ],
+                "properties": {
+                  "payment_uids": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "Payments to settle. Each must be `CAPTURED`, on the Simulator gateway, yours, and not already settled.",
+                    "example": [
+                      "PR1234567890",
+                      "PR1234567891"
+                    ]
+                  },
+                  "refund_uids": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "default": [],
+                    "description": "Refunds to fold into the same settlement. Each debits the total at its full amount and carries no fee of its own.",
+                    "example": [
+                      "RF9876543210"
+                    ]
+                  },
+                  "chargeback_uids": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "default": [],
+                    "description": "Chargebacks to fold in. Same treatment as refunds.",
+                    "example": [
+                      "CB5555555555"
+                    ]
+                  }
+                }
+              },
+              "example": {
+                "payment_uids": [
+                  "PR1234567890",
+                  "PR1234567891"
+                ],
+                "refund_uids": [
+                  "RF9876543210"
+                ],
+                "chargeback_uids": [
+                  "CB5555555555"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Settlement created and the payments marked settled.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Payments marked as settled successfully"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "settlement_id": {
+                          "type": "string",
+                          "description": "UID of the new settlement — use it with the settlement detail and list endpoints.",
+                          "example": "ST7362075798"
+                        },
+                        "utr_number": {
+                          "type": "string",
+                          "description": "Simulated bank UTR reference.",
+                          "example": "bb6708d5-367f-4ff4-baea-2743a7e649a3"
+                        },
+                        "settlement_completed_at": {
+                          "type": "string",
+                          "format": "date-time",
+                          "example": "2026-08-12T11:32:50.432063Z"
+                        },
+                        "forex_rate": {
+                          "type": "string",
+                          "description": "Always `\"96\"` in the simulator.",
+                          "example": "96"
+                        },
+                        "settlement_amount": {
+                          "type": "string",
+                          "description": "Net settled amount, in **rupees** with 2 decimals — not integer paise.",
+                          "example": "791.00"
+                        },
+                        "settlement_charges": {
+                          "type": "string",
+                          "description": "Total platform fees, in rupees. Payments only.",
+                          "example": "50.00"
+                        },
+                        "settlement_gst": {
+                          "type": "string",
+                          "description": "Total GST on those fees, in rupees. Payments only.",
+                          "example": "9.00"
+                        }
+                      }
+                    }
+                  }
+                },
+                "example": {
+                  "success": true,
+                  "message": "Payments marked as settled successfully",
+                  "data": {
+                    "settlement_id": "ST7362075798",
+                    "utr_number": "bb6708d5-367f-4ff4-baea-2743a7e649a3",
+                    "settlement_completed_at": "2026-08-12T11:32:50.432063Z",
+                    "forex_rate": "96",
+                    "settlement_amount": "791.00",
+                    "settlement_charges": "50.00",
+                    "settlement_gst": "9.00"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation failed, a UID did not resolve, a payment is not on the Simulator gateway / not captured / already settled, or the endpoint was called in production. `error.code` is `ERR_SERVICE_ERROR_000`; `error.details` says which.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v3_ErrorResponse"
+                },
+                "example": {
+                  "success": false,
+                  "error": {
+                    "code": "ERR_SERVICE_ERROR_000",
+                    "message": "Payment gateway error",
+                    "details": {
+                      "payment_uids": "PR4673100896 is not on the simulator gateway"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected processing failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v3_ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pg/refunds/{refund_id}/simulate-status/": {
+      "post": {
+        "summary": "Set refund status (sandbox)",
+        "description": "Forces a refund straight to any status, bypassing the normal `INITIATED → REFUNDED/FAILED` progression, and fires the same webhook a real status change would. Lets one refund exercise every branch of your refund handler, including statuses a real rail reaches rarely.\n\n**Sandbox only.** This endpoint returns `400` in production, and operates only on transactions created through the **Simulator** payment gateway — a real Cashfree or ICICI transaction is rejected.\n\nUnlike a real rail, a refund may be moved **out of** a terminal status (`REFUNDED` / `FAILED`) and back again — deliberately, so you do not need a fresh refund per branch.\n\n**PSP callers must send `X-Merchant-ID`.**",
+        "tags": [
+          "Refund"
+        ],
+        "security": [
+          {
+            "clientAuth": [],
+            "clientSecretAuth": [],
+            "merchantAuth": [],
+            "apiVersionHeader": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "refund_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "UID of the refund.",
+            "example": "RF7019490071"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "status"
+                ],
+                "properties": {
+                  "status": {
+                    "type": "string",
+                    "enum": [
+                      "INITIATED",
+                      "PROCESSING",
+                      "REFUNDED",
+                      "FAILED",
+                      "REVERSED",
+                      "ON_HOLD",
+                      "BANK_REJECTED_REFUND"
+                    ],
+                    "description": "Target status. **Uppercase** — `\"refunded\"` is rejected, `\"REFUNDED\"` is accepted.",
+                    "example": "FAILED"
+                  },
+                  "status_message": {
+                    "type": "string",
+                    "nullable": true,
+                    "description": "Custom message carried into the webhook. Omit for the default for that status.",
+                    "example": "Beneficiary account closed"
+                  },
+                  "bank_ref_num": {
+                    "type": "string",
+                    "nullable": true,
+                    "description": "Bank reference to stamp on the refund. Left unchanged if omitted.",
+                    "example": "BANKREF123"
+                  }
+                }
+              },
+              "example": {
+                "status": "FAILED",
+                "status_message": "Beneficiary account closed",
+                "bank_ref_num": "BANKREF123"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Refund updated. A transition to a status the refund already held still returns 200, but sends no webhook.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Refund status updated successfully"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "refund_id": {
+                          "type": "string",
+                          "example": "RF7019490071"
+                        },
+                        "payment_id": {
+                          "type": "string",
+                          "example": "PR1195868571"
+                        },
+                        "refund_amount": {
+                          "type": "string",
+                          "description": "In **rupees** with 2 decimals.",
+                          "example": "250.00"
+                        },
+                        "refund_status": {
+                          "type": "string",
+                          "description": "Current status, **lowercase** — you send `FAILED` and receive `failed`.",
+                          "example": "failed"
+                        },
+                        "refunded_at": {
+                          "type": "string",
+                          "format": "date-time",
+                          "nullable": true,
+                          "description": "Stamped when the refund first reaches `REFUNDED`.",
+                          "example": "2026-08-12T11:32:25.256618Z"
+                        },
+                        "message": {
+                          "type": "string",
+                          "example": "Beneficiary account closed"
+                        },
+                        "settlement_details": {
+                          "type": "object",
+                          "description": "Settlement breakdown once the refund is settled; `{}` otherwise."
+                        },
+                        "reference_id": {
+                          "type": "string",
+                          "nullable": true,
+                          "description": "Your reference, if supplied at refund creation."
+                        },
+                        "created_at": {
+                          "type": "string",
+                          "format": "date-time",
+                          "example": "2026-08-12T11:32:25.255318Z"
+                        }
+                      }
+                    }
+                  }
+                },
+                "example": {
+                  "success": true,
+                  "message": "Refund status updated successfully",
+                  "data": {
+                    "refund_id": "RF7019490071",
+                    "payment_id": "PR1195868571",
+                    "refund_amount": "250.00",
+                    "refund_status": "failed",
+                    "refunded_at": "2026-08-12T11:32:25.256618Z",
+                    "message": "Beneficiary account closed",
+                    "settlement_details": {},
+                    "reference_id": null,
+                    "created_at": "2026-08-12T11:32:25.255318Z"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid or missing `status`, a refund not on the Simulator gateway, or the endpoint called in production. `error.code` is `ERR_REFUND_002`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v3_ErrorResponse"
+                },
+                "example": {
+                  "success": false,
+                  "error": {
+                    "code": "ERR_REFUND_002",
+                    "message": "Validation error",
+                    "details": {
+                      "status": "\"NOT_A_STATUS\" is not a valid choice."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No such refund for this merchant. **This response does not use the standard envelope** — it returns a bare `detail` string.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "detail": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "example": {
+                  "detail": "No DomesticPaymentRefund matches the given query."
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected processing failure. `error.code` is `ERR_SERVICE_ERROR_000` here, unlike the 400s on this endpoint.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v3_ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {


### PR DESCRIPTION
Documents the two sandbox simulator endpoints, both already on `main` in the backend.

```
POST /pg/settlements/mark-settled/
POST /pg/refunds/{refund_id}/simulate-status/
```

| Page | Group |
|---|---|
| `api-reference/v3/settlement/mark-settled` | Settlement |
| `api-reference/v3/refunds/simulate-status` | Refund |

Plus both endpoints in `openapi/v3/openapi.json` and the nav entries.

## Why these matter

Settlement and refund progression are the two parts of the lifecycle a merchant **cannot trigger themselves** — both wait on the bank. That makes their webhook handlers the hardest to test and the most likely to be wrong in production. These endpoints drive them on demand, and neither was documented.

## Placement

In the Settlement and Refund groups rather than a new "Simulator" one, following the existing `vba/simulate-transfer` precedent. Someone looking for "how do I settle" looks under Settlement — splitting simulator endpoints into their own section would hide them from exactly the person who needs them.

Both pages lead with a sandbox-only warning, since they return `400` in production and reject anything not on the Simulator gateway.

## What's documented beyond the request/response shapes

The endpoint schemas don't tell you any of this, and each one costs a support ticket:

- **The simulated fee schedule** — 5% platform fee, 18% GST on it, forex fixed at `96` — with a worked example. Noted as simulator figures for checking your reconciliation *arithmetic*, not for predicting production amounts.
- **Refunds and chargebacks carry no fee of their own.** They debit the settlement at full amount, so `settlement_charges` and `settlement_gst` cover payments only.
- **Which webhook each target refund status fires**, including that `INITIATED` fires none.
- **Webhooks fire only on a genuine transition.** Re-setting the status a refund already holds returns `200` and sends nothing — which otherwise reads as a broken webhook.
- **Terminal refund statuses are reversible here**, on purpose, so one refund can exercise every branch of a handler. The page gives a walk-through order.
- **Requests take uppercase, responses return lowercase.** Sending `"refunded"` is the most likely cause of a `400` on that endpoint.
- **Amounts are strings in rupees, not integer paise.**
- **`404` on the refund endpoint returns a bare `{"detail": ...}`**, not the standard envelope, so it needs its own handling. And it's a `404` rather than `403` — someone else's refund is simply not found.
- **Unresolvable UIDs report only the first failure per category**, so fix them one at a time or pre-validate.

## Independent of the LRS docs PR

[#66](https://github.com/akhil-kumar-mg-mint/docs/pull/66) is gated on [eximpe_pacb_backend#1849](https://github.com/EximPe/eximpe_pacb_backend/pull/1849) shipping. These endpoints are already live, so this PR is documenting shipped behaviour and can merge on its own schedule — which is why it's separate rather than a second commit on that branch.

Both touch `openapi/v3/openapi.json` and `docs.json`, but in different places; whichever merges second may need a trivial rebase.

## Validation

- `mint broken-links` — no broken links from either new page
- `mint validate` — same single pre-existing warning as clean `main`, nothing added
- `openapi/v3/openapi.json` re-serialised at the same 2-space indent, so the diff is 391 added lines with no reformatting
- Every path, field name, status value and error code checked against the implementation in `partner_api/views/settlement.py`, `partner_api/views/refund.py` and their serializers

## Note

`openapi/v3/openapi.json` still isn't registered in `docs.json`'s `openapi` array — see the write-up in [#66](https://github.com/akhil-kumar-mg-mint/docs/pull/66). It affects these two pages' playground the same way it affects the existing v3 LRS pages. Worth fixing once, separately.
