### PR TITLE
docs: use meaningful auth header placeholders in api reference code samples

### DIFF
--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -16488,7 +16488,7 @@
         "in": "header",
         "description": "**Client Application ID** - Your unique application identifier used to authenticate API requests. You can find your Client ID in the Developer Settings section of the merchant dashboard.",
         "x-displayName": "Client ID",
-        "x-example": "your-client-id"
+        "x-default": "your-client-id"
       },
       "clientSecretAuth": {
         "type": "apiKey",
@@ -16496,7 +16496,7 @@
         "in": "header",
         "description": "**Client Secret Key** - Your secret key used alongside the Client ID for secure authentication. Keep this confidential and never expose it in client-side code. Available in the Developer Settings section of the merchant dashboard.",
         "x-displayName": "Client Secret",
-        "x-example": "your-client-secret"
+        "x-default": "your-client-secret"
       },
       "merchantAuth": {
         "type": "apiKey",
@@ -16504,7 +16504,7 @@
         "in": "header",
         "description": "**Merchant Identifier** - The unique ID for the merchant account. This is required for PSP (Payment Service Provider) merchants who manage multiple merchant accounts. You can find merchant IDs in the Merchant Management section of the dashboard.",
         "x-displayName": "Merchant ID",
-        "x-example": "your-merchant-id"
+        "x-default": "sub-merchant-id"
       },
       "apiVersionHeader": {
         "type": "apiKey",
@@ -16512,7 +16512,7 @@
         "in": "header",
         "description": "**API Version** - Specifies which version of the API to use (e.g., '1.X.X', '2.X.X', or '3.X.X'). This header allows you to control which API version your integration uses. Default version information is available in the Developer Settings.",
         "x-displayName": "API Version",
-        "x-example": "3.0.0"
+        "x-default": "3.0.0"
       }
     }
   },

--- a/openapi/v2-subscriptions.json
+++ b/openapi/v2-subscriptions.json
@@ -825,7 +825,7 @@
         "in": "header",
         "description": "**Client Application ID** - Your unique application identifier used to authenticate API requests. You can find your Client ID in the Developer Settings section of the merchant dashboard.",
         "x-displayName": "Client ID",
-        "x-example": "your-client-id"
+        "x-default": "your-client-id"
       },
       "clientSecretAuth": {
         "type": "apiKey",
@@ -833,7 +833,7 @@
         "in": "header",
         "description": "**Client Secret Key** - Your secret key used alongside the Client ID for secure authentication. Keep this confidential and never expose it in client-side code. Available in the Developer Settings section of the merchant dashboard.",
         "x-displayName": "Client Secret",
-        "x-example": "your-client-secret"
+        "x-default": "your-client-secret"
       },
       "merchantAuth": {
         "type": "apiKey",
@@ -841,14 +841,15 @@
         "in": "header",
         "description": "**Merchant Identifier** - The unique ID for the merchant account. This is required for PSP (Payment Service Provider) merchants who manage multiple merchant accounts. You can find merchant IDs in the Merchant Management section of the dashboard.",
         "x-displayName": "Merchant ID",
-        "x-example": "your-merchant-id"
+        "x-default": "sub-merchant-id"
       },
       "apiVersionHeader": {
         "type": "apiKey",
         "name": "X-API-Version",
         "in": "header",
         "description": "**API Version** - Specifies which version of the API to use (e.g., '2.X.X'). This header allows you to control which API version your integration uses.",
-        "x-displayName": "API Version"
+        "x-displayName": "API Version",
+        "x-default": "2.0.0"
       }
     }
   }


### PR DESCRIPTION
## Summary
This PR will make the API reference code samples show a meaningful placeholder for each authentication header instead of the same `<api-key>` for all four.

- Replaced `x-example` with `x-default` on the four `apiKey` security schemes in `openapi/openapi.json` and `openapi/v2-subscriptions.json`.
- `x-example` is not an OpenAPI field and is not read by Mintlify, so it never took effect — `x-default` is the extension Mintlify reads.
- Values: `X-Client-ID` → `your-client-id`, `X-Client-Secret` → `your-client-secret`, `X-Merchant-ID` → `sub-merchant-id` (it is the sub-merchant's id supplied by a PSP caller, not the caller's own), `X-API-Version` → `3.0.0` (`2.0.0` in the v2 subscriptions spec, since it is a literal version string and not a credential).
- `openapi/v3/openapi.json` is not referenced by `docs.json` and renders nothing, so it is left untouched.

## ClickUp
- https://app.clickup.com/t/86d423f73

## Test plan
- [x] Verified locally in a browser against `mintlify dev`
- [x] `/api-reference/v3/order/create` renders `X-API-Version: 3.0.0`, `X-Client-ID: your-client-id`, `X-Client-Secret: your-client-secret`, `X-Merchant-ID: sub-merchant-id` — no `<api-key>`
- [x] `/api-reference/v2/subscriptions/create-intent` renders `X-API-Version: 2.0.0` plus the same three values
- [x] Both specs parse as valid JSON
- [x] Diff confined to `components.securitySchemes`; no endpoint or schema content changed

Note: the values are substituted on client hydration, so the initial server-rendered HTML still contains `<api-key>` for a moment before the sample settles. That is Mintlify's rendering behaviour, unchanged by this PR.

Note: the repo's pinned `mintlify@4.0.588` cannot start (`setupNext.js` destructures `const [requestHandler] = await initialize(...)`, which its bundled Next 15.5 no longer returns as an array). Verification was done with `npx mintlify@latest dev`; the pin is worth bumping in a separate PR.

Refs: CU-86d423f73
