### PR TITLE
docs(v3): the submit endpoint takes JSON, and stops showing what it takes

### DIFF
--- a/api-reference/v3/lrs/submit-verification-details.mdx
+++ b/api-reference/v3/lrs/submit-verification-details.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Submit Verification Details'
-description: "Send a payment's verification details — fields and files — in one call, keyed by the codes the requirements name."
+description: "Send a payment's verification details — fields and document refs — in one JSON call, keyed by the codes the requirements name."
 openapi: 'POST /pg/lrs/payments/{payment_id}/verification/'
 ---
 
@@ -13,9 +13,9 @@ There is nothing to map between them:
 | Where you read it | What you do with it |
 |---|---|
 | the webhook's `action_required_fields[].field` | the keys you put in `fields` |
-| the webhook's `action_required_documents[].document` | what you name the files |
+| the webhook's `action_required_documents[].document` | the `code` you put in `documents` |
 | `fields[].code` (here, and from `GET`) | the key you put in `fields` |
-| `documents[].code` (here, and from `GET`) | what you name the file |
+| `documents[].code` (here, and from `GET`) | the `code` you put in `documents` |
 
 The response repeats the requirement shape, so one call tells you what is left.
 
@@ -26,7 +26,7 @@ The response repeats the requirement shape, so one call tells you what is left.
     [`LRS_VERIFICATION_NEEDED`](/api-reference/v3/webhooks/lrs-verification-needed) lists what the payment owes — each entry a code, a sentence saying why, and whether it can be waived.
   </Step>
   <Step title="You send what you have">
-    Fields as a map, documents as files. Partial is fine.
+    Fields as a map, documents as refs from [Upload Document](/api-reference/v3/lrs/upload-document). Partial is fine.
   </Step>
   <Step title="You read what is left">
     The response repeats `fields` and `documents`, re-evaluated. What is left is the `satisfied: false` entries.
@@ -317,48 +317,6 @@ sets:
   release on your side — but only if you are reading it rather than reproducing
   it.
 </Warning>
-
-## Two ways to send it
-
-### JSON
-
-Reference documents you uploaded earlier through [Upload Document](/api-reference/v3/lrs/upload-document).
-
-```json
-{
-  "fields": {
-    "buyer_city": "Bengaluru",
-    "remitter_pan": "ABCDE1234F",
-    "remitter_relation": "SELF",
-    "buyer_declaration": true,
-    "amount_to_be_settled": "150000.00"
-  },
-  "documents": [
-    { "code": "student_passport", "ref": "a1b2c3d4-5e6f-7a8b-9c0d-1e2f3a4b5c6d" },
-    { "code": "traveller_visas", "waiver_reason": "Destination is visa-free" }
-  ],
-  "finalize": true
-}
-```
-
-### Multipart — one call, no pre-upload
-
-Send the files themselves as parts named `document.<code>`.
-
-```bash
-curl -X POST 'https://api-pacb-uat.eximpe.com/pg/lrs/payments/PR6938527534/verification/' \
-  -H 'X-Client-ID: your-client-id' \
-  -H 'X-Client-Secret: your-client-secret' \
-  -H 'X-API-Version: 3.0.0' \
-  -F 'fields={"buyer_city":"Bengaluru","payment_term":"Advance"}' \
-  -F 'document.student_passport=@passport.pdf' \
-  -F 'document.university_id_card=@student-id.png' \
-  -F 'finalize=true'
-```
-
-`fields` and `documents` are JSON encoded as strings; each file is its own part. Parts whose name does not start with `document.` are ignored, so an incidental part costs you nothing.
-
-Five documents is one request instead of six.
 
 ## Partial sends are merged
 

--- a/openapi/v3/openapi.json
+++ b/openapi/v3/openapi.json
@@ -3057,7 +3057,7 @@
       },
       "post": {
         "summary": "Submit verification details",
-        "description": "Sends verification details for a payment, keyed by the same codes the requirements and the [`LRS_VERIFICATION_NEEDED`](/api-reference/v3/webhooks/lrs-verification-needed) webhook use. There is nothing to map: the event's `action_required_fields[].field` are the keys you put in `fields`, and its `action_required_documents[].document` are what you name the files.\n\n**Two ways to send it, one endpoint.**\n\n* `application/json` — `fields` as an object, `documents` as a list of `{code, ref}` naming files uploaded earlier through [Upload Document](/api-reference/v3/lrs/upload-document).\n* `multipart/form-data` — the same `fields` and `documents` as JSON strings, plus the files themselves as parts named `document.<code>` (for example `document.student_passport`). No pre-upload round trip: five documents in one request instead of six.\n\n**Partial sends are merged, never replaced.** Send what you have; the response tells you what is left. Nothing you sent earlier is wiped by a later call.\n\n**Completion is automatic.** Once nothing is outstanding the set is run through the verification gateway — PAN verification, the sender-to-account-holder match, the TCS recomputation and the LRS counter posting. Pass `finalize: false` to stage without triggering it.\n\n**PSP callers must send `X-Merchant-ID`.**",
+        "description": "Sends verification details for a payment, keyed by the same codes the requirements and the [`LRS_VERIFICATION_NEEDED`](/api-reference/v3/webhooks/lrs-verification-needed) webhook use. There is nothing to map: the event's `action_required_fields[].field` are the keys you put in `fields`, and its `action_required_documents[].document` are the `code` you put in `documents`.\n\n**JSON only.** `fields` is an object; `documents` is a list of `{code, ref}` naming files uploaded earlier through [Upload Document](/api-reference/v3/lrs/upload-document). Files are never posted to this endpoint — a `multipart/form-data` request is a `415`.\n\n**Partial sends are merged, never replaced.** Send what you have; the response tells you what is left. Nothing you sent earlier is wiped by a later call.\n\n**Completion is automatic.** Once nothing is outstanding the set is run through the verification gateway — PAN verification, the sender-to-account-holder match, the TCS recomputation and the LRS counter posting. Pass `finalize: false` to stage without triggering it.\n\n**PSP callers must send `X-Merchant-ID`.**",
         "tags": [
           "LRS"
         ],
@@ -3102,7 +3102,7 @@
                   },
                   "documents": {
                     "type": "array",
-                    "description": "Documents by reference, or waivers. Files sent inline as multipart parts do not need an entry here.",
+                    "description": "Documents by reference, or waivers.",
                     "items": {
                       "type": "object",
                       "required": [
@@ -3170,38 +3170,6 @@
                   }
                 ],
                 "finalize": true
-              }
-            },
-            "multipart/form-data": {
-              "schema": {
-                "type": "object",
-                "description": "`fields` and `documents` are JSON encoded as strings. Each file is its own part named `document.<code>` — `document.student_passport`, `document.loa`. Parts whose name does not start with `document.` are ignored.",
-                "properties": {
-                  "fields": {
-                    "type": "string",
-                    "description": "The `fields` object, JSON encoded as a string.",
-                    "example": "{\"buyer_city\":\"Bengaluru\",\"payment_term\":\"Advance\"}"
-                  },
-                  "documents": {
-                    "type": "string",
-                    "description": "The `documents` array, JSON encoded as a string. Only needed for references and waivers.",
-                    "example": "[{\"code\":\"loa\",\"ref\":\"a1b2c3d4-5e6f-7a8b-9c0d-1e2f3a4b5c6d\"}]"
-                  },
-                  "finalize": {
-                    "type": "string",
-                    "example": "true"
-                  },
-                  "document.student_passport": {
-                    "type": "string",
-                    "format": "binary",
-                    "description": "Example of an inline file part. Any `document.<code>` part is accepted, where `<code>` is a document code from the requirements."
-                  }
-                },
-                "additionalProperties": {
-                  "type": "string",
-                  "format": "binary",
-                  "description": "Further `document.<code>` file parts."
-                }
               }
             }
           }


### PR DESCRIPTION
Follow-up to #66, which merged before these two landed.

## Multipart is gone from the page and the spec

Files are never posted to `POST /pg/lrs/payments/{payment_id}/verification/` — it answers a `multipart/form-data` request with a `415`. The page offered it as the second of "two ways to send it" (fields and documents JSON-encoded as strings, each file its own `document.<code>` part, "five documents in one request instead of six"), and the spec carried a matching request body. Both described a call that cannot be made.

The frontmatter description and the two mapping-table rows now say the same thing as the rest: documents are refs from [Upload Document](/api-reference/v3/lrs/upload-document).

## The hand-written request examples are gone too

The page is generated from the spec, so Mintlify already renders the request schema and a code sample beside it. A JSON body and a curl block maintained by hand next to a generated pair of the same is two sources for one fact, and the hand-written one is the one that goes stale.

Nothing is lost: that documents are refs rather than files is stated in **The loop** and in every purpose-code example above it.