### PR TITLE
docs(v3): purpose_code and business_model on Upload Payment Verification Details

### DIFF
--- a/api-reference/v3/payment/upload-verification-details.mdx
+++ b/api-reference/v3/payment/upload-verification-details.mdx
@@ -31,6 +31,46 @@ Credits that land in a Virtual Bank Account create a payment against an order. I
   </Step>
 </Steps>
 
+## Declaring the purpose code and business model
+
+Most of what this endpoint takes is a fact about the goods or the buyer. Two of them are not: `purpose_code` and `business_model` say what the payment *is*, and they are what the platform files it under.
+
+They appear in `action_required_fields` on [`VERIFICATION_NEEDED`](/api-reference/v3/webhooks/verification-needed) when nothing has declared them, alongside the ordinary order fields:
+
+```json
+{
+  "action_required_fields": ["buyer_name", "hs_code", "purpose_code"]
+}
+```
+
+Send them back the same way you send anything else on that list:
+
+```json
+{
+  "buyer_name": "Acme Imports Pvt Ltd",
+  "hs_code": "6109",
+  "purpose_code": "S0305",
+  "business_model": "B2C"
+}
+```
+
+| Field | What it says |
+|---|---|
+| `purpose_code` | The FEMA/FETERS purpose code this order settles under. Must be one your merchant account is enabled for — an unrecognised or un-enabled code is rejected with a `400` rather than stored. |
+| `business_model` | `B2C` or `B2B`. |
+
+<Note>
+  **Both are optional, and omitting one is not the same as clearing it.** Leave either out and whatever was already declared stays. Correcting a buyer's postal code does not retract the purpose code you declared last week.
+</Note>
+
+<Warning>
+  **Sending `business_model` is what makes it declared.** The field defaults to `B2C`, so an order nobody has classified and an order that genuinely is B2C read the same until you say which. That is why the webhook can list `business_model` as outstanding on an order that already shows `B2C` — and why sending `"business_model": "B2C"` is a real answer, not a no-op.
+</Warning>
+
+<Tip>
+  For a payment settling under an LRS purpose code, declaring these switches it over: it stops receiving `VERIFICATION_NEEDED` and starts receiving [`LRS_VERIFICATION_NEEDED`](/api-reference/v3/webhooks/lrs-verification-needed), which carries the full purpose-code-specific requirement set — documents included — instead of a flat list of field names.
+</Tip>
+
 ## Test Data
 
 When testing this API in the **sandbox environment**, you must use the following specific test values for the API to work correctly:

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -6353,6 +6353,21 @@
             "type": "string",
             "maxLength": 30,
             "description": "HS code. Required when type_of_goods is GOODS, PHYSICAL_GOODS, or DIGITAL_GOODS; optional for SERVICE."
+          },
+          "purpose_code": {
+            "type": "string",
+            "maxLength": 255,
+            "description": "FEMA/FETERS purpose code this order settles under. Send it when `VERIFICATION_NEEDED` lists `purpose_code` in `action_required_fields`. Must be one your merchant account is enabled for — an unrecognised or un-enabled code is a 400, not a stored value. Omit it to leave whatever was already declared untouched.",
+            "example": "S0305"
+          },
+          "business_model": {
+            "type": "string",
+            "enum": [
+              "B2C",
+              "B2B"
+            ],
+            "description": "Whether the buyer is a business (B2B) or a consumer (B2C). Send it when `VERIFICATION_NEEDED` lists `business_model` in `action_required_fields`. Sending it is what makes it declared — the field defaults to `B2C`, so an order nobody classified is indistinguishable from one that genuinely is B2C until you say so. Omit it to leave an earlier declaration untouched.",
+            "example": "B2C"
           }
         }
       },


### PR DESCRIPTION
## What

`POST /pg/payments/{uid}/upload-verification-details/` takes two optional fields — `purpose_code` and `business_model`. Send them and they are written to the PG order; omit them and whatever was already declared stays.

Neither was documented. `VERIFICATION_NEEDED` lists both in `action_required_fields` when nothing has declared them and points the reader at this endpoint to supply what is listed, so a merchant following both pages reached a list it could not answer.

## Changes

- **`api-reference/v3/payment/upload-verification-details.mdx`** — a "Declaring the purpose code and business model" section: what each field says, the webhook payload that asks for them, and the request that answers it.
- **`openapi/openapi.json`** — `purpose_code` and `business_model` on `v2_UploadVerificationDetailsRequest`.

## Two things the prose has to carry

- **Omitting one is not clearing it.** Correcting a buyer's postal code does not retract last week's purpose code.
- **Sending `business_model` is what makes it declared.** The field defaults to `B2C`, so an unclassified order and a genuinely-B2C one read the same until the merchant says which. That is why the webhook can list `business_model` as outstanding on an order already showing `B2C`, and why sending `"business_model": "B2C"` is a real answer rather than the no-op it looks like.

## Note for review

The schema lives in the **shared** `openapi/openapi.json`, so the v2 page picks the two fields up as well. That is correct — both pages document the same Django endpoint.

## Backend

EximPe/eximpe_pacb_backend#1862, which is what makes the two fields accepted. Merge that first, or this documents an API that rejects them as unknown keys.

Supersedes #68 (same commit, branched off the LRS branch before it merged).