### PR TITLE
docs(v3): the submit response says where the payment stands, and nothing else

### DIFF
--- a/api-reference/v3/lrs/submit-verification-details.mdx
+++ b/api-reference/v3/lrs/submit-verification-details.mdx
@@ -14,10 +14,10 @@ There is nothing to map between them:
 |---|---|
 | the webhook's `action_required_fields[].field` | the keys you put in `fields` |
 | the webhook's `action_required_documents[].document` | the `code` you put in `documents` |
-| `fields[].code` (here, and from `GET`) | the key you put in `fields` |
-| `documents[].code` (here, and from `GET`) | the `code` you put in `documents` |
+| the `GET`'s `fields[].code` | the key you put in `fields` |
+| the `GET`'s `documents[].code` | the `code` you put in `documents` |
 
-The response repeats the requirement shape, so one call tells you what is left.
+The response is two keys — the payment, and where it now stands.
 
 ## The loop
 
@@ -28,11 +28,11 @@ The response repeats the requirement shape, so one call tells you what is left.
   <Step title="You send what you have">
     Fields as a map, documents as refs from [Upload Document](/api-reference/v3/lrs/upload-document). Partial is fine.
   </Step>
-  <Step title="You read what is left">
-    The response repeats `fields` and `documents`, re-evaluated. What is left is the `satisfied: false` entries.
+  <Step title="You read where the payment stands">
+    `ACTION_REQUIRED` — still waiting on you. `IN_REVIEW` — with us, nothing further to send.
   </Step>
-  <Step title="It completes itself">
-    Once nothing is outstanding the set is verified automatically and `verification` reports the outcome.
+  <Step title="You read what is left, if anything is">
+    From [`GET`](/api-reference/v3/lrs/verification-requirements) on the same path, or from the next event. Both name it in the codes you just sent.
   </Step>
 </Steps>
 
@@ -322,7 +322,7 @@ sets:
 
 Send three fields today and two tomorrow and you have sent five. Nothing you sent earlier is wiped by a later call, and a document sent twice supersedes the first without discarding it.
 
-This is deliberate: nobody collects a passport scan, a visa and a letter of admission in the same instant.
+This is deliberate: nobody collects a passport scan, a visa and a letter of admission in the same instant. [`GET`](/api-reference/v3/lrs/verification-requirements) the same path whenever you want to know where that has left the payment.
 
 ## Values
 
@@ -340,109 +340,92 @@ Field values are strings, numbers or booleans.
 
 Omit a key rather than sending `null` or an empty string. A boolean requirement — the LRS declarations — is only satisfied by `true`; `false` reads as not yet answered.
 
-## Completion
+## The response
 
-`finalize` defaults to `true` and applies only to a **complete** set. It never forces an incomplete one through.
-
-When a complete set is submitted it runs through the verification gateway — PAN verification, the sender-to-account-holder match, the TCS recomputation and the exactly-once LRS counter posting. The outcome comes back in `verification`:
+Two keys, whatever you sent:
 
 ```json
-"verification": {
-  "handed_off": true,
-  "status": "under_review",
-  "tcs_check": "match",
-  "missing": [],
-  "reason": null,
-  "outstanding": "0.00"
+{
+  "success": true,
+  "message": "Verification details received",
+  "data": {
+    "payment_id": "PR6938527534",
+    "status": "ACTION_REQUIRED"
+  }
 }
 ```
+
+| `status` | What it means | What to do |
+|---|---|---|
+| `IN_REVIEW` | The set was complete, the verification gateway took it, and it passed. The payment is with us. | Nothing. |
+| `ACTION_REQUIRED` | Something is still owed — the set is short, you held it back with `finalize: false`, or the gateway did not pass the payment. | Find out what, then send it. |
 
 <Warning>
-  **`handed_off: true` does not mean the payment passed.** It means the gateway
-  took the set and reached a verdict. Read `status`, which is `under_review` or
-  `action_required`. A complete set that fails PAN verification, the sender match
-  or the money check is `handed_off: true` with `status: "action_required"` — the
-  payment stays where it was, and `missing` says what to fix.
+  **`ACTION_REQUIRED` never means your details were discarded.** Everything that
+  reached us is held against the payment, whether the call ended in a refusal, a
+  vendor outage or a half-finished set. You re-send the one thing that failed,
+  not the whole set.
 </Warning>
 
-### `status: "action_required"` — accepted, not passed
+### Finding out what is still owed
 
+This response does not say. Two places already do, and a third copy is one more
+thing that can drift out of step with them:
+
+<CardGroup cols={2}>
+  <Card title="GET the same path" icon="list-check" href="/api-reference/v3/lrs/verification-requirements">
+    The whole requirement set, each entry carrying `satisfied`. Authoritative, idempotent, and safe to poll.
+  </Card>
+  <Card title="LRS_VERIFICATION_NEEDED" icon="webhook" href="/api-reference/v3/webhooks/lrs-verification-needed#after-a-submit-that-did-not-pass">
+    Fires on a refusal too, naming the same codes with a sentence per item — plus `outstanding` and `reason`, which no requirement list can carry.
+  </Card>
+</CardGroup>
+
+A refusal is where the two differ, and it is worth knowing which to read.
 Everything the requirement list named can be supplied and the payment still not
-proceed, because supplying a PAN is not the same as it verifying. When that
-happens you get:
+proceed, because supplying a PAN is not the same as it verifying — and the
+requirement list has nothing to say about that. The event does: it is where a
+shortfall's rupee figure (`outstanding`), a headline conclusion (`reason`:
+`PAN_NOT_VERIFIED`, `SENDER_NAME_MISMATCH`, `PURPOSE_CODE_NOT_ALLOWED`,
+`PURPOSE_CODE_NOT_IN_REGISTRY`) and the per-item sentences you can show a payer
+all live.
 
-```json
-"verification": {
-  "handed_off": true,
-  "status": "action_required",
-  "tcs_check": "match",
-  "missing": ["outstanding"],
-  "reason": null,
-  "outstanding": "12500.00"
-}
-```
+## Completion
 
-| Key | What it carries |
-|---|---|
-| `status` | `under_review` (accepted and proceeding) or `action_required` (the payment stays parked). |
-| `missing` | What did not pass, as tokens — see the table below. Empty on `under_review`. |
-| `reason` | One headline conclusion where one exists, `null` otherwise. `null` is normal, not an error. |
-| `outstanding` | The money still owed, in rupees, as a decimal string. `"0.00"` when nothing is — the key is always there whenever `handed_off` is `true`, so there is no absence to handle. |
-| `tcs_check` | `match`, `mismatch`, or `n/a` where the check was never reached (an early reject on the PAN or the purpose code). |
+`finalize` defaults to `true` and applies only to a **complete** set. It never forces an incomplete one through. Pass `finalize: false` to stage details without triggering verification — useful when you know more is coming, and the response is `ACTION_REQUIRED` because, deliberately, it still is.
 
-The same payment also gets an
-[`LRS_VERIFICATION_NEEDED`](/api-reference/v3/webhooks/lrs-verification-needed#after-a-submit-that-did-not-pass)
-webhook carrying the same conclusion in the requirement codes, with a sentence
-per item you can show a payer. This response is the synchronous half of it — you
-do not have to wait for the event to know what happened.
-
-**`missing` tokens**
-
-| Token | What to do |
-|---|---|
-| `outstanding` | The credit does not cover the payment. `outstanding` says by how much — either the buyer tops it up (link it with `linked_payment_id` when you re-submit) or you declare a smaller `amount_to_be_settled`. |
-| `remitter.pan` | The PAN did not verify against the name and date of birth. Re-send all three. |
-| `declarations` | `buyer_declaration` was not affirmed. |
-| `primary_person` | The remitter is not the person the remittance is for, so name them — `student_name`, `student_dob`, `student_passport_number`. |
-| `tcs` | The TCS figure does not reconcile with ours. You do not declare TCS; raise this with us rather than re-sending. |
-| `purpose_code` | The code is not one this account may use, or not one we recognise. Fixed on the order, not here. |
-| `documents.<type>` | That document did not reach the gateway. Re-send the file. |
+When a complete set is submitted it runs through the verification gateway — PAN verification, the sender-to-account-holder match, the TCS recomputation and the exactly-once LRS counter posting. `IN_REVIEW` means all of that passed.
 
 <Warning>
   **Travel purpose codes cannot complete yet.** A complete set on `S0306`,
-  `S0304` or `S0303` returns `status: "action_required"` with
-  `missing: ["purpose_code"]` and `reason: "PURPOSE_CODE_NOT_IN_REGISTRY"`,
-  however much you send. Collecting and submitting works — the details are held
-  against the payment — but the payment will not advance until the travel rules
-  are in place. Education (`S0305`, `S1107`) is unaffected.
+  `S0304` or `S0303` comes back `ACTION_REQUIRED` with
+  `reason: "PURPOSE_CODE_NOT_IN_REGISTRY"` on the event, however much you send.
+  Collecting and submitting works — the details are held against the payment —
+  but the payment will not advance until the travel rules are in place.
+  Education (`S0305`, `S1107`) is unaffected.
 </Warning>
 
-**`reason` values**
+### When the handoff itself does not happen
 
-`PAN_NOT_VERIFIED`, `SENDER_NAME_MISMATCH`, `PURPOSE_CODE_NOT_ALLOWED`,
-`PURPOSE_CODE_NOT_IN_REGISTRY` — or `null`, which is what a shortfall and every
-other multi-check refusal returns.
+A complete set can fail to reach a verdict at all:
 
-<Note>
-  **Nothing you sent is lost.** Re-send only the thing that failed; it merges
-  with what is already held, and the payment stays submittable throughout.
-</Note>
-
-### `handed_off: false` — the set never reached a verdict
-
-When `handed_off` is `false`, `reason` says why:
-
-| `reason` | What it means |
-|---|---|
-| `GATEWAY_REJECTED` | Verification declined — for example the payment is already past submit. `detail` says which. |
-| `GATEWAY_UNAVAILABLE` | A dependency was briefly unreachable. **Your details are saved.** Repeat the request to complete it; you do not need to re-send anything. |
-| `NO_DOWNSTREAM_GATEWAY` | This purpose code has no automated verification; details are recorded and the payment proceeds through review. |
+| What happened | `status` | Event |
+|---|---|---|
+| A dependency was briefly unreachable. **Your details are saved**; repeat the request to complete it, re-sending nothing. | `ACTION_REQUIRED` | none |
+| Verification declined the payment — for example it is already past submit. | `ACTION_REQUIRED` | none |
+| This purpose code has no automated verification: details are recorded and the payment proceeds through review. | `IN_REVIEW` | none |
 
 <Note>
-  Details are stored before verification is attempted and are never discarded by it. An outage costs you a retry, never a re-send.
+  **`ACTION_REQUIRED` with a complete requirement set and no event means the
+  handoff did not land.** Repeat the same request — the set is still complete, so
+  it is retried rather than re-sent, and an outage costs you one call. A refusal
+  the gateway actually reached always arrives as an event, so silence is what
+  tells the two apart.
 </Note>
 
-Pass `finalize: false` to stage details without triggering verification — useful when you know more is coming.
+<Note>
+  Details are stored before verification is attempted and are never discarded by it.
+</Note>
 
 ## Where each value goes
 

--- a/openapi/v3/openapi.json
+++ b/openapi/v3/openapi.json
@@ -3057,7 +3057,7 @@
       },
       "post": {
         "summary": "Submit verification details",
-        "description": "Sends verification details for a payment, keyed by the same codes the requirements and the [`LRS_VERIFICATION_NEEDED`](/api-reference/v3/webhooks/lrs-verification-needed) webhook use. There is nothing to map: the event's `action_required_fields[].field` are the keys you put in `fields`, and its `action_required_documents[].document` are the `code` you put in `documents`.\n\n**JSON only.** `fields` is an object; `documents` is a list of `{code, ref}` naming files uploaded earlier through [Upload Document](/api-reference/v3/lrs/upload-document). Files are never posted to this endpoint — a `multipart/form-data` request is a `415`.\n\n**Partial sends are merged, never replaced.** Send what you have; the response tells you what is left. Nothing you sent earlier is wiped by a later call.\n\n**Completion is automatic.** Once nothing is outstanding the set is run through the verification gateway — PAN verification, the sender-to-account-holder match, the TCS recomputation and the LRS counter posting. Pass `finalize: false` to stage without triggering it.\n\n**PSP callers must send `X-Merchant-ID`.**",
+        "description": "Sends verification details for a payment, keyed by the same codes the requirements and the [`LRS_VERIFICATION_NEEDED`](/api-reference/v3/webhooks/lrs-verification-needed) webhook use. There is nothing to map: the event's `action_required_fields[].field` are the keys you put in `fields`, and its `action_required_documents[].document` are the `code` you put in `documents`.\n\n**JSON only.** `fields` is an object; `documents` is a list of `{code, ref}` naming files uploaded earlier through [Upload Document](/api-reference/v3/lrs/upload-document). Files are never posted to this endpoint — a `multipart/form-data` request is a `415`.\n\n**Partial sends are merged, never replaced.** Send what you have; nothing you sent earlier is wiped by a later call.\n\n**Completion is automatic.** Once nothing is outstanding the set is run through the verification gateway — PAN verification, the sender-to-account-holder match, the TCS recomputation and the LRS counter posting. Pass `finalize: false` to stage without triggering it.\n\n**The response is two keys**: `payment_id` and `status`. For what is still owed, [`GET`](/api-reference/v3/lrs/verification-requirements) this same path or read the event — both name it in the codes you just sent.\n\n**PSP callers must send `X-Merchant-ID`.**",
         "tags": [
           "LRS"
         ],
@@ -3176,7 +3176,7 @@
         },
         "responses": {
           "200": {
-            "description": "Details received. The body carries the full state after the write, so a single call tells you what is left.",
+            "description": "Details received. The body says where the payment now stands, and nothing else.",
             "content": {
               "application/json": {
                 "schema": {
@@ -3191,587 +3191,48 @@
                       "example": "Verification details received"
                     },
                     "data": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/v3_VerificationState"
+                      "type": "object",
+                      "properties": {
+                        "payment_id": {
+                          "type": "string",
+                          "description": "The payment these details were recorded against.",
+                          "example": "PR6938527534"
                         },
-                        {
-                          "type": "object",
-                          "properties": {
-                            "accepted": {
-                              "type": "object",
-                              "description": "What this call took, echoed back.",
-                              "properties": {
-                                "fields": {
-                                  "type": "array",
-                                  "items": {
-                                    "type": "string"
-                                  }
-                                },
-                                "documents": {
-                                  "type": "array",
-                                  "items": {
-                                    "type": "string"
-                                  }
-                                }
-                              }
-                            },
-                            "verification": {
-                              "type": "object",
-                              "description": "Present only once a complete set was run through the gateway.",
-                              "properties": {
-                                "handed_off": {
-                                  "type": "boolean"
-                                },
-                                "status": {
-                                  "type": "string",
-                                  "enum": [
-                                    "under_review",
-                                    "action_required"
-                                  ]
-                                },
-                                "tcs_check": {
-                                  "type": "string",
-                                  "enum": [
-                                    "match",
-                                    "mismatch",
-                                    "n/a"
-                                  ]
-                                },
-                                "missing": {
-                                  "type": "array",
-                                  "items": {
-                                    "type": "string"
-                                  },
-                                  "description": "What did not pass, as tokens: `outstanding`, `remitter.pan`, `declarations`, `primary_person`, `tcs`, `purpose_code`, or `documents.<type>`. Empty on `under_review`."
-                                },
-                                "reason": {
-                                  "type": "string",
-                                  "nullable": true,
-                                  "description": "One headline conclusion, or `null` — which is normal, not an error. On `handed_off: true` with `status: action_required`: `PAN_NOT_VERIFIED`, `SENDER_NAME_MISMATCH`, `PURPOSE_CODE_NOT_ALLOWED` or `PURPOSE_CODE_NOT_IN_REGISTRY`; a shortfall and every other multi-check refusal returns `null`. On `handed_off: false`: `GATEWAY_REJECTED`, `GATEWAY_UNAVAILABLE` (your details are saved — retry to complete) or `NO_DOWNSTREAM_GATEWAY`."
-                                },
-                                "outstanding": {
-                                  "type": "string",
-                                  "description": "Money still owed on this payment, in rupees, as a decimal string — principal plus fees, GST and TCS, less what was received. `\"0.00\"` when nothing is owed. Always present when `handed_off` is `true`.",
-                                  "example": "12500.00"
-                                }
-                              }
-                            }
-                          }
+                        "status": {
+                          "type": "string",
+                          "enum": [
+                            "IN_REVIEW",
+                            "ACTION_REQUIRED"
+                          ],
+                          "description": "Where the payment stands after this call. `IN_REVIEW` — the set was complete, the verification gateway took it, and nothing more is owed from you. `ACTION_REQUIRED` — something still is: the set is short, you passed `finalize: false`, or the gateway did not pass the payment. It never means your details were discarded.",
+                          "example": "ACTION_REQUIRED"
                         }
-                      ]
+                      }
                     }
                   }
                 },
                 "examples": {
-                  "partial": {
-                    "summary": "Partial send — still incomplete",
-                    "description": "`finalize` applies only to a complete set, so nothing was handed downstream and there is no `verification` block.",
+                  "action_required": {
+                    "summary": "ACTION_REQUIRED — something is still owed",
+                    "description": "A partial send, a `finalize: false` hold, and a complete set the gateway refused all answer the same way: the payment is still waiting on you. `GET /pg/lrs/payments/{payment_id}/verification/` for the codes still outstanding; a gateway refusal also arrives as an `LRS_VERIFICATION_NEEDED` event carrying a sentence per item, plus `outstanding` and `reason`.",
                     "value": {
                       "success": true,
                       "message": "Verification details received",
                       "data": {
                         "payment_id": "PR6938527534",
-                        "order_uid": "OD3376378679",
-                        "status": "incomplete",
-                        "is_lrs": true,
-                        "business_model": "B2C",
-                        "purpose_code": "S0305",
-                        "purpose_code_description": "Travel for education (including fees, hostel expenses etc.)",
-                        "requirement_label": "B2C · Education — LRS (with travel leg)",
-                        "fields": [
-                          {
-                            "code": "buyer_name",
-                            "label": "Buyer / remitter name",
-                            "requirement": "REQUIRED",
-                            "waivable": false,
-                            "satisfied": true,
-                            "provided": true
-                          },
-                          {
-                            "code": "buyer_address_line_1",
-                            "label": "Buyer address line 1",
-                            "requirement": "REQUIRED",
-                            "waivable": false,
-                            "satisfied": false,
-                            "provided": false
-                          },
-                          {
-                            "code": "buyer_city",
-                            "label": "Buyer city",
-                            "requirement": "REQUIRED",
-                            "waivable": false,
-                            "satisfied": true,
-                            "provided": true
-                          },
-                          {
-                            "code": "buyer_state",
-                            "label": "Buyer state",
-                            "requirement": "REQUIRED",
-                            "waivable": false,
-                            "satisfied": false,
-                            "provided": false
-                          },
-                          {
-                            "code": "buyer_postal_code",
-                            "label": "Buyer PIN code",
-                            "requirement": "REQUIRED",
-                            "waivable": false,
-                            "satisfied": false,
-                            "provided": false
-                          },
-                          {
-                            "code": "buyer_email",
-                            "label": "Buyer email",
-                            "requirement": "REQUIRED",
-                            "waivable": false,
-                            "satisfied": false,
-                            "provided": false
-                          },
-                          {
-                            "code": "buyer_phone",
-                            "label": "Buyer phone",
-                            "requirement": "REQUIRED",
-                            "waivable": false,
-                            "satisfied": false,
-                            "provided": false
-                          },
-                          {
-                            "code": "invoice_number",
-                            "label": "Invoice number",
-                            "requirement": "REQUIRED",
-                            "waivable": false,
-                            "satisfied": false,
-                            "provided": false
-                          },
-                          {
-                            "code": "invoice_date",
-                            "label": "Invoice date",
-                            "requirement": "REQUIRED",
-                            "waivable": false,
-                            "satisfied": false,
-                            "provided": false
-                          },
-                          {
-                            "code": "invoice_amount",
-                            "label": "Invoice amount",
-                            "requirement": "REQUIRED",
-                            "waivable": false,
-                            "satisfied": true,
-                            "provided": true
-                          },
-                          {
-                            "code": "purpose_code",
-                            "label": "FEMA purpose code",
-                            "requirement": "REQUIRED",
-                            "waivable": false,
-                            "satisfied": true,
-                            "provided": true
-                          },
-                          {
-                            "code": "payment_term",
-                            "label": "Payment term",
-                            "requirement": "REQUIRED",
-                            "waivable": false,
-                            "satisfied": false,
-                            "provided": false
-                          },
-                          {
-                            "code": "remitter_name",
-                            "label": "Remitter name (as per PAN)",
-                            "requirement": "REQUIRED",
-                            "waivable": false,
-                            "satisfied": false,
-                            "provided": false
-                          },
-                          {
-                            "code": "remitter_pan",
-                            "label": "Remitter PAN",
-                            "requirement": "REQUIRED",
-                            "waivable": false,
-                            "satisfied": true,
-                            "provided": true
-                          },
-                          {
-                            "code": "remitter_dob",
-                            "label": "Remitter date of birth (as per PAN)",
-                            "requirement": "REQUIRED",
-                            "waivable": false,
-                            "satisfied": false,
-                            "provided": false
-                          },
-                          {
-                            "code": "remitter_relation",
-                            "label": "Remitter's relation to the person the remittance is for (SELF / PARENT / GUARDIAN / SPOUSE / SIBLING / OTHER)",
-                            "requirement": "REQUIRED",
-                            "waivable": false,
-                            "satisfied": false,
-                            "provided": false
-                          },
-                          {
-                            "code": "buyer_declaration",
-                            "label": "The remitter has declared that they are a person resident in India; that this remittance, together with all remittances made during the current financial year, is within the applicable LRS limit; and that this remittance is not for any purpose prohibited under Rule 3 read with Schedule I of the Foreign Exchange Management (Current Account Transactions) Rules, 2000.",
-                            "requirement": "REQUIRED",
-                            "waivable": false,
-                            "satisfied": false,
-                            "provided": false
-                          },
-                          {
-                            "code": "amount_to_be_settled",
-                            "label": "Amount to be settled for this payment, in INR",
-                            "requirement": "REQUIRED",
-                            "waivable": false,
-                            "satisfied": false,
-                            "provided": false
-                          },
-                          {
-                            "code": "student_name",
-                            "label": "Student name",
-                            "requirement": "REQUIRED",
-                            "waivable": false,
-                            "satisfied": false,
-                            "provided": false
-                          },
-                          {
-                            "code": "student_dob",
-                            "label": "Student date of birth",
-                            "requirement": "REQUIRED",
-                            "waivable": false,
-                            "satisfied": false,
-                            "provided": false
-                          },
-                          {
-                            "code": "student_passport_number",
-                            "label": "Student passport number",
-                            "requirement": "REQUIRED",
-                            "waivable": false,
-                            "satisfied": false,
-                            "provided": false
-                          }
-                        ],
-                        "documents": [
-                          {
-                            "code": "student_passport",
-                            "label": "Student passport",
-                            "requirement": "REQUIRED",
-                            "waivable": false,
-                            "satisfied": true,
-                            "provided": true
-                          },
-                          {
-                            "code": "student_visa",
-                            "label": "Student visa",
-                            "requirement": "REQUIRED",
-                            "waivable": false,
-                            "satisfied": false,
-                            "provided": false,
-                            "alternative_group": "student_status_proof"
-                          },
-                          {
-                            "code": "university_id_card",
-                            "label": "University ID card",
-                            "requirement": "REQUIRED",
-                            "waivable": false,
-                            "satisfied": false,
-                            "provided": false,
-                            "alternative_group": "student_status_proof"
-                          },
-                          {
-                            "code": "loa",
-                            "label": "Letter of admission / offer letter",
-                            "requirement": "REQUIRED",
-                            "waivable": false,
-                            "satisfied": false,
-                            "provided": false
-                          },
-                          {
-                            "code": "invoice",
-                            "label": "Fee invoice",
-                            "requirement": "OPTIONAL",
-                            "waivable": false,
-                            "satisfied": true,
-                            "provided": false
-                          },
-                          {
-                            "code": "relationship_declaration",
-                            "label": "Relationship self-declaration",
-                            "requirement": "CONDITIONAL",
-                            "waivable": false,
-                            "satisfied": true,
-                            "provided": false,
-                            "condition": "relation_not_self"
-                          }
-                        ],
-                        "accepted": {
-                          "fields": [
-                            "buyer_city",
-                            "remitter_pan"
-                          ],
-                          "documents": [
-                            "student_passport"
-                          ]
-                        }
+                        "status": "ACTION_REQUIRED"
                       }
                     }
                   },
-                  "complete": {
-                    "summary": "Complete set — handed off, and refused",
-                    "description": "Everything the purpose code asks for was sent, so the set went to the verification gateway. `handed_off: true` means it reached a verdict, not that the payment passed — this one is short by ₹12,500 and stays in Action Required.",
+                  "in_review": {
+                    "summary": "IN_REVIEW — the payment is with us",
+                    "description": "Everything the purpose code asks for was sent, the set went through the verification gateway, and it passed. Nothing further to send.",
                     "value": {
                       "success": true,
                       "message": "Verification details received",
                       "data": {
                         "payment_id": "PR6938527534",
-                        "order_uid": "OD3376378679",
-                        "status": "complete",
-                        "is_lrs": true,
-                        "business_model": "B2C",
-                        "purpose_code": "S0305",
-                        "purpose_code_description": "Travel for education (including fees, hostel expenses etc.)",
-                        "requirement_label": "B2C · Education — LRS (with travel leg)",
-                        "fields": [
-                          {
-                            "code": "buyer_name",
-                            "label": "Buyer / remitter name",
-                            "requirement": "REQUIRED",
-                            "waivable": false,
-                            "satisfied": true,
-                            "provided": true
-                          },
-                          {
-                            "code": "buyer_address_line_1",
-                            "label": "Buyer address line 1",
-                            "requirement": "REQUIRED",
-                            "waivable": false,
-                            "satisfied": true,
-                            "provided": true
-                          },
-                          {
-                            "code": "buyer_city",
-                            "label": "Buyer city",
-                            "requirement": "REQUIRED",
-                            "waivable": false,
-                            "satisfied": true,
-                            "provided": true
-                          },
-                          {
-                            "code": "buyer_state",
-                            "label": "Buyer state",
-                            "requirement": "REQUIRED",
-                            "waivable": false,
-                            "satisfied": true,
-                            "provided": true
-                          },
-                          {
-                            "code": "buyer_postal_code",
-                            "label": "Buyer PIN code",
-                            "requirement": "REQUIRED",
-                            "waivable": false,
-                            "satisfied": true,
-                            "provided": true
-                          },
-                          {
-                            "code": "buyer_email",
-                            "label": "Buyer email",
-                            "requirement": "REQUIRED",
-                            "waivable": false,
-                            "satisfied": true,
-                            "provided": true
-                          },
-                          {
-                            "code": "buyer_phone",
-                            "label": "Buyer phone",
-                            "requirement": "REQUIRED",
-                            "waivable": false,
-                            "satisfied": true,
-                            "provided": true
-                          },
-                          {
-                            "code": "invoice_number",
-                            "label": "Invoice number",
-                            "requirement": "REQUIRED",
-                            "waivable": false,
-                            "satisfied": true,
-                            "provided": true
-                          },
-                          {
-                            "code": "invoice_date",
-                            "label": "Invoice date",
-                            "requirement": "REQUIRED",
-                            "waivable": false,
-                            "satisfied": true,
-                            "provided": true
-                          },
-                          {
-                            "code": "invoice_amount",
-                            "label": "Invoice amount",
-                            "requirement": "REQUIRED",
-                            "waivable": false,
-                            "satisfied": true,
-                            "provided": true
-                          },
-                          {
-                            "code": "purpose_code",
-                            "label": "FEMA purpose code",
-                            "requirement": "REQUIRED",
-                            "waivable": false,
-                            "satisfied": true,
-                            "provided": true
-                          },
-                          {
-                            "code": "payment_term",
-                            "label": "Payment term",
-                            "requirement": "REQUIRED",
-                            "waivable": false,
-                            "satisfied": true,
-                            "provided": true
-                          },
-                          {
-                            "code": "remitter_name",
-                            "label": "Remitter name (as per PAN)",
-                            "requirement": "REQUIRED",
-                            "waivable": false,
-                            "satisfied": true,
-                            "provided": true
-                          },
-                          {
-                            "code": "remitter_pan",
-                            "label": "Remitter PAN",
-                            "requirement": "REQUIRED",
-                            "waivable": false,
-                            "satisfied": true,
-                            "provided": true
-                          },
-                          {
-                            "code": "remitter_dob",
-                            "label": "Remitter date of birth (as per PAN)",
-                            "requirement": "REQUIRED",
-                            "waivable": false,
-                            "satisfied": true,
-                            "provided": true
-                          },
-                          {
-                            "code": "remitter_relation",
-                            "label": "Remitter's relation to the person the remittance is for (SELF / PARENT / GUARDIAN / SPOUSE / SIBLING / OTHER)",
-                            "requirement": "REQUIRED",
-                            "waivable": false,
-                            "satisfied": true,
-                            "provided": true
-                          },
-                          {
-                            "code": "buyer_declaration",
-                            "label": "The remitter has declared that they are a person resident in India; that this remittance, together with all remittances made during the current financial year, is within the applicable LRS limit; and that this remittance is not for any purpose prohibited under Rule 3 read with Schedule I of the Foreign Exchange Management (Current Account Transactions) Rules, 2000.",
-                            "requirement": "REQUIRED",
-                            "waivable": false,
-                            "satisfied": true,
-                            "provided": true
-                          },
-                          {
-                            "code": "amount_to_be_settled",
-                            "label": "Amount to be settled for this payment, in INR",
-                            "requirement": "REQUIRED",
-                            "waivable": false,
-                            "satisfied": true,
-                            "provided": true
-                          },
-                          {
-                            "code": "student_name",
-                            "label": "Student name",
-                            "requirement": "REQUIRED",
-                            "waivable": false,
-                            "satisfied": true,
-                            "provided": true
-                          },
-                          {
-                            "code": "student_dob",
-                            "label": "Student date of birth",
-                            "requirement": "REQUIRED",
-                            "waivable": false,
-                            "satisfied": true,
-                            "provided": true
-                          },
-                          {
-                            "code": "student_passport_number",
-                            "label": "Student passport number",
-                            "requirement": "REQUIRED",
-                            "waivable": false,
-                            "satisfied": true,
-                            "provided": true
-                          }
-                        ],
-                        "documents": [
-                          {
-                            "code": "student_passport",
-                            "label": "Student passport",
-                            "requirement": "REQUIRED",
-                            "waivable": false,
-                            "satisfied": true,
-                            "provided": true
-                          },
-                          {
-                            "code": "student_visa",
-                            "label": "Student visa",
-                            "requirement": "REQUIRED",
-                            "waivable": false,
-                            "satisfied": true,
-                            "provided": true,
-                            "alternative_group": "student_status_proof"
-                          },
-                          {
-                            "code": "university_id_card",
-                            "label": "University ID card",
-                            "requirement": "REQUIRED",
-                            "waivable": false,
-                            "satisfied": true,
-                            "provided": true,
-                            "alternative_group": "student_status_proof"
-                          },
-                          {
-                            "code": "loa",
-                            "label": "Letter of admission / offer letter",
-                            "requirement": "REQUIRED",
-                            "waivable": false,
-                            "satisfied": true,
-                            "provided": true
-                          },
-                          {
-                            "code": "invoice",
-                            "label": "Fee invoice",
-                            "requirement": "OPTIONAL",
-                            "waivable": false,
-                            "satisfied": true,
-                            "provided": false
-                          },
-                          {
-                            "code": "relationship_declaration",
-                            "label": "Relationship self-declaration",
-                            "requirement": "CONDITIONAL",
-                            "waivable": false,
-                            "satisfied": true,
-                            "provided": false,
-                            "condition": "relation_not_self"
-                          }
-                        ],
-                        "accepted": {
-                          "fields": [
-                            "amount_to_be_settled",
-                            "buyer_declaration"
-                          ],
-                          "documents": [
-                            "loa",
-                            "student_visa"
-                          ]
-                        },
-                        "verification": {
-                          "handed_off": true,
-                          "status": "action_required",
-                          "tcs_check": "match",
-                          "missing": [
-                            "outstanding"
-                          ],
-                          "reason": null,
-                          "outstanding": "12500.00"
-                        }
+                        "status": "IN_REVIEW"
                       }
                     }
                   }


### PR DESCRIPTION
`POST /pg/lrs/payments/{payment_id}/verification/` used to return the whole requirement set, what the call had just accepted, and the gateway's `verification` verdict block. Three shapes to parse for a call whose answer is one fact — and two of them are second copies of what the `GET` and `LRS_VERIFICATION_NEEDED` already say.

The response is now two keys:

```json
{"payment_id": "PR6938527534", "status": "ACTION_REQUIRED"}
```

- `IN_REVIEW` — the set was complete, verification took it, and it passed. Nothing further to send.
- `ACTION_REQUIRED` — something is still owed: the set is short, `finalize: false` held it back, or the gateway did not pass the payment.

**What changed on the page**
- The loop's third step reads the status instead of a re-evaluated requirement list, and a fourth points at the `GET` and the event for *what* is owed.
- "The response" replaces the `verification` / `missing` / `reason` / `outstanding` / `tcs_check` reference, with a card pair pointing at the two surfaces that do carry that detail.
- The handoff-failure table now maps each case to its `status` and notes that none of the three emits an event — so `ACTION_REQUIRED` on a complete set with no event means a retry, not a re-send.
- `openapi/v3/openapi.json`: the 200 schema drops `accepted` and `verification`; `status` carries the two-value description, and both examples are rewritten.

Backend counterpart: EximPe/eximpe_pacb_backend#1862.