### PR TITLE
Document remarks on the VBA simulate-transfer API

### DIFF
--- a/integration-guide/v3/web-integration/virtual-accounts.mdx
+++ b/integration-guide/v3/web-integration/virtual-accounts.mdx
@@ -120,7 +120,8 @@ curl -X POST 'https://api-pacb-uat.eximpe.com/pg/vba/simulate-transfer/' \
       "utr": "TESTUTR0001",
       "remitter_name": "John Doe",
       "remitter_account": "123456789012",
-      "remitter_ifsc": "YESB0CMSNOC"
+      "remitter_ifsc": "YESB0CMSNOC",
+      "remarks": "Invoice INV-2025-0091"
     }
   }'
 ```

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -4087,6 +4087,11 @@
                         "type": "string",
                         "description": "IFSC code of the destination VBA.",
                         "example": "UTIB0CCH274"
+                      },
+                      "remarks": {
+                        "type": "string",
+                        "description": "Optional. Payer narration stored on the payment as payment_message. Applied for ICICI VBAs; ignored for Cashfree VBAs (Cashfree's simulate API has no narration field).",
+                        "example": "Invoice INV-2025-0091"
                       }
                     }
                   }
@@ -4101,7 +4106,8 @@
                   "phone": "9876543210",
                   "remitter_account": "123456789012",
                   "remitter_ifsc": "YESB0CMSNOC",
-                  "vba_ifsc": "UTIB0CCH274"
+                  "vba_ifsc": "UTIB0CCH274",
+                  "remarks": "Invoice INV-2025-0091"
                 }
               }
             }

--- a/openapi/v3/openapi.json
+++ b/openapi/v3/openapi.json
@@ -2084,17 +2084,23 @@
                       },
                       "payment_date": {
                         "type": "string",
-                        "description": "ICICI only (optional). Payer payment date; maps to PayerPaymentDate.",
-                        "example": "2026-07-07"
+                        "description": "ICICI only (optional). Payer payment date in DD/MM/YYYY format; maps to PayerPaymentDate. If omitted or unparseable, the payment's completion time falls back to the time the simulated credit is processed.",
+                        "example": "07/07/2026"
                       },
                       "bank_txn_number": {
                         "type": "string",
-                        "description": "ICICI only (optional). Maps to BankInternalTransactionNumber.",
+                        "description": "ICICI only (optional). Maps to BankInternalTransactionNumber, stored as the payment's bank reference number.",
                         "example": "ICICITXN00012345"
+                      },
+                      "remarks": {
+                        "type": "string",
+                        "description": "Optional. Payer narration stored on the payment as payment_message. Applied for ICICI VBAs; ignored for Cashfree VBAs (Cashfree's simulate API has no narration field).",
+                        "example": "Invoice INV-2025-0091"
                       },
                       "sender_remark": {
                         "type": "string",
-                        "description": "ICICI only (optional). Free-text narration; maps to SenderRemark.",
+                        "deprecated": true,
+                        "description": "Deprecated alias of remarks (ICICI only). Used only when remarks is absent.",
                         "example": "Invoice INV-2025-0091"
                       }
                     }

--- a/openapi/v3/openapi.json
+++ b/openapi/v3/openapi.json
@@ -1039,14 +1039,6 @@
                                   "INACTIVE"
                                 ],
                                 "example": "ACTIVE"
-                              },
-                              "vba_provider": {
-                                "type": "string",
-                                "enum": [
-                                  "CASHFREE",
-                                  "ICICI"
-                                ],
-                                "example": "ICICI"
                               }
                             }
                           }
@@ -1072,8 +1064,7 @@
                         "vba_bank_code": "UTIB",
                         "vba_account_number": "9461257424586202",
                         "vba_ifsc": "UTIB0CCH274",
-                        "vba_status": "ACTIVE",
-                        "vba_provider": "ICICI"
+                        "vba_status": "ACTIVE"
                       },
                       {
                         "uid": "VBA_8e2a0b3c4d",
@@ -1082,8 +1073,7 @@
                         "vba_bank_code": "YESB",
                         "vba_account_number": "9461257424586203",
                         "vba_ifsc": "YESB0CMSNOC",
-                        "vba_status": "INACTIVE",
-                        "vba_provider": "CASHFREE"
+                        "vba_status": "INACTIVE"
                       }
                     ]
                   }


### PR DESCRIPTION
## What

Docs for the new `remarks` input on `POST /pg/vba/simulate-transfer/` (backend PR: EximPe/eximpe_pacb_backend#1873).

- **openapi/v3/openapi.json** and **openapi/openapi.json**: add optional `vba_simulation.remarks` — payer narration stored on the payment as `payment_message`; applied for ICICI VBAs, ignored for Cashfree VBAs (Cashfree's simulate API has no narration field). `sender_remark` is marked deprecated as its alias.
- Corrected `payment_date` to its actual `DD/MM/YYYY` format (the old ISO example would silently fail to parse) and documented the completion-time fallback; clarified `bank_txn_number` is stored as the payment's bank reference number.
- Added `remarks` to the v3 integration-guide simulate curl example.