### PR TITLE
docs(v3): drop payment_term, which the backend no longer asks for

### DIFF
--- a/api-reference/v3/lrs/submit-verification-details.mdx
+++ b/api-reference/v3/lrs/submit-verification-details.mdx
@@ -63,7 +63,6 @@ sets:
     "buyer_phone": "+919876543210",
     "invoice_number": "INV-2026-0041",
     "invoice_date": "2026-08-01",
-    "payment_term": "Advance",
     "remitter_name": "RAVI KUMAR",
     "remitter_pan": "ABCPK1234F",
     "remitter_dob": "1985-04-12",
@@ -107,7 +106,6 @@ sets:
     "buyer_phone": "+919876543210",
     "invoice_number": "INV-2026-0041",
     "invoice_date": "2026-08-01",
-    "payment_term": "Advance",
     "remitter_name": "RAVI KUMAR",
     "remitter_pan": "ABCPK1234F",
     "remitter_dob": "1985-04-12",
@@ -146,7 +144,6 @@ sets:
     "buyer_phone": "+919876543210",
     "invoice_number": "INV-2026-0041",
     "invoice_date": "2026-08-01",
-    "payment_term": "Advance",
     "remitter_name": "RAVI KUMAR",
     "remitter_pan": "ABCPK1234F",
     "remitter_dob": "1985-04-12",
@@ -195,7 +192,6 @@ sets:
     "buyer_phone": "+919876543210",
     "invoice_number": "INV-2026-0041",
     "invoice_date": "2026-08-01",
-    "payment_term": "Advance",
     "remitter_name": "RAVI KUMAR",
     "remitter_pan": "ABCPK1234F",
     "remitter_dob": "1985-04-12",
@@ -244,7 +240,6 @@ sets:
     "buyer_phone": "+919876543210",
     "invoice_number": "INV-2026-0041",
     "invoice_date": "2026-08-01",
-    "payment_term": "Advance",
     "remitter_name": "RAVI KUMAR",
     "remitter_pan": "ABCPK1234F",
     "remitter_dob": "1985-04-12",
@@ -429,14 +424,13 @@ A complete set can fail to reach a verdict at all:
 
 ## Where each value goes
 
-Most fields flow into the verification and settlement record. Three are collected
+Most fields flow into the verification and settlement record. Two are collected
 but held rather than forwarded, and it is worth knowing which:
 
 | Field | Where it goes |
 |---|---|
 | `buyer_name` | Held. The credit's own sender name on the order is authoritative — the LRS own-account check compares the verified PAN holder against *that*, so a submitted value must not overwrite it. |
 | `purpose_code` | Held. Read from the order, which is what the settlement file uses. |
-| `payment_term` | Held. Nothing in the settlement record holds it yet; your answer is kept against the payment until something does. |
 
 Everything else reaches the verification gateway. TCS is not collected at all —
 EximPe computes it.

--- a/api-reference/v3/lrs/verification-requirements.mdx
+++ b/api-reference/v3/lrs/verification-requirements.mdx
@@ -142,14 +142,6 @@ Complete, unedited responses: an education payment (`S0305`) with nothing suppli
         "provided": true
       },
       {
-        "code": "payment_term",
-        "label": "Payment term",
-        "requirement": "REQUIRED",
-        "waivable": false,
-        "satisfied": false,
-        "provided": false
-      },
-      {
         "code": "remitter_name",
         "label": "Remitter name (as per PAN)",
         "requirement": "REQUIRED",
@@ -424,7 +416,7 @@ lands here before it lands in any table.
 ### Fields
 
 Every LRS code asks for the common core (buyer name, address, contact, invoice number
-and date, invoice amount, purpose code, payment term), the remitter's verified identity
+and date, invoice amount, purpose code), the remitter's verified identity
 (`remitter_name`, `remitter_pan`, `remitter_dob`, `remitter_relation`),
 `buyer_declaration`, and `amount_to_be_settled`. On top of that:
 

--- a/api-reference/v3/webhooks/lrs-verification-needed.mdx
+++ b/api-reference/v3/webhooks/lrs-verification-needed.mdx
@@ -123,11 +123,6 @@ trimmed, so what you see is what arrives.
         "waivable": false
       },
       {
-        "field": "payment_term",
-        "message": "Required for this purpose code.",
-        "waivable": false
-      },
-      {
         "field": "remitter_name",
         "message": "Required for this purpose code.",
         "waivable": false
@@ -251,11 +246,6 @@ trimmed, so what you see is what arrives.
         "waivable": false
       },
       {
-        "field": "payment_term",
-        "message": "Required for this purpose code.",
-        "waivable": false
-      },
-      {
         "field": "remitter_name",
         "message": "Required for this purpose code.",
         "waivable": false
@@ -365,11 +355,6 @@ trimmed, so what you see is what arrives.
       },
       {
         "field": "invoice_date",
-        "message": "Required for this purpose code.",
-        "waivable": false
-      },
-      {
-        "field": "payment_term",
         "message": "Required for this purpose code.",
         "waivable": false
       },
@@ -487,11 +472,6 @@ trimmed, so what you see is what arrives.
         "waivable": false
       },
       {
-        "field": "payment_term",
-        "message": "Required for this purpose code.",
-        "waivable": false
-      },
-      {
         "field": "remitter_name",
         "message": "Required for this purpose code.",
         "waivable": false
@@ -605,11 +585,6 @@ trimmed, so what you see is what arrives.
         "waivable": false
       },
       {
-        "field": "payment_term",
-        "message": "Required for this purpose code.",
-        "waivable": false
-      },
-      {
         "field": "remitter_name",
         "message": "Required for this purpose code.",
         "waivable": false
@@ -719,11 +694,6 @@ trimmed, so what you see is what arrives.
       },
       {
         "field": "invoice_date",
-        "message": "Required for this purpose code.",
-        "waivable": false
-      },
-      {
-        "field": "payment_term",
         "message": "Required for this purpose code.",
         "waivable": false
       },

--- a/openapi/v3/openapi.json
+++ b/openapi/v3/openapi.json
@@ -2891,14 +2891,6 @@
                         "provided": true
                       },
                       {
-                        "code": "payment_term",
-                        "label": "Payment term",
-                        "requirement": "REQUIRED",
-                        "waivable": false,
-                        "satisfied": false,
-                        "provided": false
-                      },
-                      {
                         "code": "remitter_name",
                         "label": "Remitter name (as per PAN)",
                         "requirement": "REQUIRED",
@@ -3086,7 +3078,7 @@
                 "properties": {
                   "fields": {
                     "type": "object",
-                    "description": "Answers keyed by requirement code, e.g. `{\"remitter_pan\": \"ABCDE1234F\", \"payment_term\": \"Advance\"}`. Values are strings, numbers or booleans. An unknown key is a 400 rather than a silent drop — a typo you never hear about would leave the payment waiting forever for a field you believe you sent. Omit a key rather than sending null or an empty string.",
+                    "description": "Answers keyed by requirement code, e.g. `{\"remitter_pan\": \"ABCDE1234F\", \"buyer_city\": \"Bengaluru\"}`. Values are strings, numbers or booleans. An unknown key is a 400 rather than a silent drop — a typo you never hear about would leave the payment waiting forever for a field you believe you sent. Omit a key rather than sending null or an empty string.",
                     "additionalProperties": true,
                     "example": {
                       "buyer_city": "Bengaluru",


### PR DESCRIPTION
## Summary
- The backend removed `payment_term` from the LRS verification matrix entirely (CU-86d41bk7h) — no schema column ever backed it and nothing downstream forwarded it, so it was dead weight rather than a real requirement.
- Updates every doc page that showed it as a required field or example value: the `LRS_VERIFICATION_NEEDED` webhook payload examples, the submit endpoint's example payloads and its "held not forwarded" table, the requirements-GET example response, and the matching `openapi.json` fixtures.

## Test plan
- [x] Verified no remaining `payment_term` references anywhere under `api-reference/` or `openapi/`
- [x] Validated `openapi/v3/openapi.json` is still well-formed JSON after the edit
- [x] Confirmed the three edited pages still render (200) via local `mintlify dev`