### PR TITLE
docs(v3): add sandbox testing values for the LRS PAN check

### DIFF
--- a/api-reference/v3/lrs/submit-verification-details.mdx
+++ b/api-reference/v3/lrs/submit-verification-details.mdx
@@ -422,6 +422,35 @@ A complete set can fail to reach a verdict at all:
   Details are stored before verification is attempted and are never discarded by it.
 </Note>
 
+## Sandbox testing
+
+<Warning>
+  **Simulator merchants only.** On a merchant whose payment gateway is **Simulator**, the inline PAN check this endpoint runs (step 3 of the loop above) never runs a real check — `remitter_pan`, `remitter_name` and `remitter_dob` select a canned outcome instead. On every other gateway this always runs the real check, in every environment including UAT and staging.
+</Warning>
+
+A `remitter_pan` outside the table below always verifies clean, whatever `remitter_name` or `remitter_dob` you send, so a normal test submission does not have to dodge a magic value:
+
+| `remitter_pan` | Outcome |
+|---|---|
+| `SIMUL0000I` | Invalid PAN — `reason: "PAN_NOT_VERIFIED"`, stays `ACTION_REQUIRED` |
+| `SIMUL0000N` | Valid but not an individual PAN — same `reason`, same outcome |
+| `SIMUL0000O` | Valid individual PAN, but inoperative — same `reason`, same outcome |
+| `SIMUL0000E` | Verification service unreachable — reproduces a genuine outage: `status` is `ACTION_REQUIRED`, **no event fires**, and the fix is to repeat the same request unchanged, per the table in [When the handoff itself does not happen](#when-the-handoff-itself-does-not-happen) |
+| anything else | Valid — falls through to the name/dob check below |
+
+Once the PAN itself passes:
+
+| Condition | Outcome |
+|---|---|
+| `remitter_name` is exactly `SIMULATE MISMATCH` | Name does not match — `reason: "PAN_NOT_VERIFIED"` |
+| `remitter_dob` is `1900-01-01` | Date of birth does not match — same `reason` |
+
+<Note>
+  These PAN-level and name/dob-level checks are independent, and the PAN table always wins — a magic `remitter_pan` decides the outcome before `remitter_name`/`remitter_dob` are looked at, same order [Verify PAN](/api-reference/v3/lrs/verify-pan#what-fails-first) evaluates in. To reach the four failures a *verified* PAN can still produce later in the submit — a sender-name mismatch, a short credit, a TCS disagreement, a refused purpose code — send a plain (non-magic) PAN and drive those through the fields and amount you submit instead; this table only covers the PAN check itself.
+</Note>
+
+This selection also applies to [Verify PAN](/api-reference/v3/lrs/verify-pan) called standalone, for the same merchant.
+
 ## Where each value goes
 
 Most fields flow into the verification and settlement record. Two are collected

--- a/api-reference/v3/lrs/verify-pan.mdx
+++ b/api-reference/v3/lrs/verify-pan.mdx
@@ -3,3 +3,68 @@ title: 'Verify PAN'
 description: "Verify a buyer's PAN against income-tax records. A verified PAN is the gateway to the LRS buyer flow."
 openapi: 'POST /pg/pan/verify/'
 ---
+
+## Overview
+
+Checks a PAN against income-tax records and records the verdict. [Submit Verification Details](/api-reference/v3/lrs/submit-verification-details) calls this inline for the remitter's PAN when it is not already verified, so most integrations never call it directly — it exists for verifying a PAN ahead of time, or re-checking one after fixing the buyer's details.
+
+A repeat check of an already-verified PAN with the same name and date of birth returns the stored verdict without re-checking. A new PAN, changed details, or a prior failure triggers a fresh check.
+
+## Sandbox testing
+
+<Warning>
+  **Simulator merchants only.** On a merchant whose payment gateway is **Simulator**, this call never runs a real PAN check — the PAN and name/dob you send select a canned outcome instead, both here and inside [Submit Verification Details](/api-reference/v3/lrs/submit-verification-details#sandbox-testing)'s inline check. On every other gateway this endpoint always runs the real check, in every environment including UAT and staging — there is no other sandbox mode for it.
+</Warning>
+
+A PAN outside the table below always verifies clean, regardless of name or date of birth, so arbitrary test data works without dodging a magic value:
+
+| `pan` | Result |
+|---|---|
+| `SIMUL0000I` | Invalid PAN |
+| `SIMUL0000N` | Valid but not an individual PAN — LRS requires an individual |
+| `SIMUL0000O` | Valid individual PAN, but inoperative (PAN–Aadhaar not linked) |
+| `SIMUL0000E` | Verification service unreachable — the call fails the same way a genuine outage would |
+| anything else | Valid, operative, individual PAN — falls through to the name/dob check below |
+
+Once the PAN itself passes, `name` and `dob` decide the rest:
+
+| Value | Result |
+|---|---|
+| `name` is exactly `SIMULATE MISMATCH` | Name does not match |
+| `dob` is `1900-01-01` | Date of birth does not match |
+| anything else | Verified |
+
+These two checks are independent of each other and of the PAN table above — a magic PAN and a magic name/dob can combine, but a magic PAN always wins since PAN-level checks run first (matching the real evaluation order below).
+
+## What fails first
+
+Only the first failing check is ever reported:
+
+<Steps>
+  <Step title="Is the PAN itself valid">
+    Malformed, or not found in income-tax records.
+  </Step>
+  <Step title="Is it an individual PAN">
+    LRS is a resident-individual scheme — a company, trust, firm or other non-individual PAN never passes, however correct the details are.
+  </Step>
+  <Step title="Is it operative">
+    A PAN not linked to Aadhaar is inoperative, and a bank will reject it downstream regardless of what we report here.
+  </Step>
+  <Step title="Does the name match">
+    Compared against income-tax records.
+  </Step>
+  <Step title="Does the date of birth match">
+    Compared against income-tax records.
+  </Step>
+</Steps>
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="Submit Verification Details" icon="paper-plane" href="/api-reference/v3/lrs/submit-verification-details">
+    Calls this check inline for the remitter's PAN.
+  </Card>
+  <Card title="Get Verification Requirements" icon="list-check" href="/api-reference/v3/lrs/verification-requirements">
+    What a payment still needs before it can be submitted.
+  </Card>
+</CardGroup>


### PR DESCRIPTION
## Summary
- Documents the Simulator-gateway sandbox behavior for the LRS PAN check: on a merchant whose payment gateway is Simulator, `remitter_pan`/`remitter_name`/`remitter_dob` (or `pan`/`name`/`dob` on the standalone endpoint) select a canned outcome instead of running a real check, in every environment including UAT and staging.
- Adds a "Sandbox testing" section with the magic-value tables to both `verify-pan.mdx` and `submit-verification-details.mdx`, cross-linked to each other.
- Keeps the vendor name out of partner-facing docs — worded generically as "the PAN check" / "verification service", consistent with the existing de-branding pass (#76).

## Test plan
- [x] `mint dev` — both pages render 200 and show the sandbox tables
- [x] `mint broken-links` — no new broken links or dangling anchors introduced